### PR TITLE
Release 1.0.1

### DIFF
--- a/competitions/utils.py
+++ b/competitions/utils.py
@@ -1,12 +1,30 @@
-from typing import Optional
+from typing import List, Optional
 
 import constants
-from competitions.data import Competition, CompetitionId
+from competitions.data import Competition, CompetitionId, ModelConstraints
 
 
-def get_competition(id: CompetitionId) -> Optional[Competition]:
-    """Returns the competition with the given id, or None if it does not exist."""
-    for x in constants.COMPETITION_SCHEDULE:
-        if x.id == id:
-            return x
+def get_model_constraints(id: CompetitionId) -> Optional[ModelConstraints]:
+    """Returns the model constraints for the given id, or None if it does not exist."""
+    return constants.MODEL_CONSTRAINTS_BY_COMPETITION_ID.get(id, None)
+
+
+def get_competition_for_block(id: CompetitionId, block: int) -> Optional[Competition]:
+    """Returns the competition for the given id at the given block, or None if it does not exist."""
+    competition_schedule = get_competition_schedule_for_block(block)
+    for comp in competition_schedule:
+        if comp.id == id:
+            return comp
     return None
+
+
+def get_competition_schedule_for_block(block: int) -> List[Competition]:
+    """Returns the competition schedule at block."""
+    competition_schedule = None
+    for b, schedule in constants.COMPETITION_SCHEDULE_BY_BLOCK:
+        if block >= b:
+            competition_schedule = schedule
+    assert (
+        competition_schedule is not None
+    ), f"No competition schedule found for block {block}"
+    return competition_schedule

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import math
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Tuple
 
 import torch
 from transformers import (
@@ -54,36 +54,49 @@ WEIGHT_SYNC_VALI_MIN_STAKE = 100_000
 WEIGHT_SYNC_MINER_MIN_PERCENT = 0.10
 # The root directory of this project.
 ROOT_DIR = Path(__file__).parent.parent
-# The maximum bytes for the hugging face repo
+# The maximum bytes for the hugging face repo.
 MAX_HUGGING_FACE_BYTES: int = 15 * 1024 * 1024 * 1024
-# TODO: Adjust below to be done by block instead as in 9 with helpers.
-# Schedule of model architectures
-COMPETITION_SCHEDULE: List[Competition] = [
-    Competition(
-        id=CompetitionId.SN9_MODEL,
-        constraints=ModelConstraints(
-            max_model_parameter_size=6_900_000_000,
-            sequence_length=4096,
-            allowed_architectures=[
-                MistralForCausalLM,
-                LlamaForCausalLM,
-                BartForCausalLM,
-                FalconForCausalLM,
-                GPTNeoXForCausalLM,
-                PhiForCausalLM,
-                GemmaForCausalLM,
-            ],
-            tokenizer="Xenova/gpt-4",
-            kwargs={
-                "torch_dtype": torch.bfloat16,
-                "attn_implementation": "flash_attention_2",
-            },
-        ),
-        reward_percentage=1.0,
+# Defined model constraints by competition id to ensure they are constant across blocks.
+MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
+    CompetitionId.SN9_MODEL: ModelConstraints(
+        max_model_parameter_size=6_900_000_000,
+        sequence_length=4096,
+        allowed_architectures=[
+            MistralForCausalLM,
+            LlamaForCausalLM,
+            BartForCausalLM,
+            FalconForCausalLM,
+            GPTNeoXForCausalLM,
+            PhiForCausalLM,
+            GemmaForCausalLM,
+        ],
+        tokenizer="Xenova/gpt-4",
+        kwargs={
+            "torch_dtype": torch.bfloat16,
+            "attn_implementation": "flash_attention_2",
+        },
+    ),
+}
+
+# Schedule of competitions by block.
+COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
+    (
+        0,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                1.0,
+            )
+        ],
     )
 ]
 
-assert math.isclose(sum(x.reward_percentage for x in COMPETITION_SCHEDULE), 1.0)
+for block_and_competitions in COMPETITION_SCHEDULE_BY_BLOCK:
+    assert math.isclose(
+        sum(competition.reward_percentage for competition in block_and_competitions[1]),
+        1.0,
+    )
 
 # ---------------------------------
 # Miner/Validator Model parameters.

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -20,7 +20,7 @@ from competitions.data import Competition, CompetitionId, ModelConstraints
 # Project Constants.
 # ---------------------------------
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/finetune/mining.py
+++ b/finetune/mining.py
@@ -76,15 +76,15 @@ async def push(
     if remote_model_store is None:
         remote_model_store = HuggingFaceModelStore()
 
-    competition = competition_utils.get_competition(competition_id)
-    if not competition:
+    model_constraints = competition_utils.get_model_constraints(competition_id)
+    if not model_constraints:
         raise ValueError("Invalid competition_id")
 
     # First upload the model to HuggingFace.
     namespace, name = utils.validate_hf_repo_id(repo)
     model_id = ModelId(namespace=namespace, name=name, competition_id=competition_id)
     model_id = await remote_model_store.upload_model(
-        Model(id=model_id, pt_model=model), competition
+        Model(id=model_id, pt_model=model), model_constraints
     )
 
     bt.logging.success("Uploaded model to hugging face.")
@@ -213,13 +213,15 @@ async def load_remote_model(
     if not model_metadata:
         raise ValueError(f"No model metadata found for miner {uid}")
 
-    competition = competition_utils.get_competition(model_metadata.id.competition_id)
-    if not competition:
+    model_constraints = competition_utils.get_model_constraints(
+        model_metadata.id.competition_id
+    )
+    if not model_constraints:
         raise ValueError("Invalid competition_id")
 
     bt.logging.success(f"Fetched model metadata: {model_metadata}")
     model: Model = await remote_model_store.download_model(
-        model_metadata.id, download_dir, competition
+        model_metadata.id, download_dir, model_constraints
     )
     return model.pt_model
 

--- a/finetune/model.py
+++ b/finetune/model.py
@@ -1,12 +1,12 @@
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
-from competitions.data import Competition
+from competitions.data import ModelConstraints
 
 
 def load_tokenizer(
-    competition: Competition, cache_dir: str = None
+    model_constraints: ModelConstraints, cache_dir: str = None
 ) -> PreTrainedTokenizer:
-    """Returns the fixed tokenizer for the given competition."""
+    """Returns the fixed tokenizer for the given model constraints."""
     return AutoTokenizer.from_pretrained(
-        competition.constraints.tokenizer, cache_dir=cache_dir
+        model_constraints.tokenizer, cache_dir=cache_dir
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bittensor==6.9.3
-flash-attn==2.5.8
+flash-attn
 huggingface_hub
 numpy==1.26.4
 python-dotenv

--- a/scripts/model_validation.py
+++ b/scripts/model_validation.py
@@ -70,19 +70,19 @@ def main():
     )
     args = parser.parse_args()
     if args.list_competitions:
-        print(constants.COMPETITION_SCHEDULE)
+        print(constants.COMPETITION_SCHEDULE_BY_BLOCK)
         return
 
-    competition = competition_utils.get_competition(args.competition_id)
-    if competition is None:
+    model_constraints = competition_utils.get_model_constraints(args.competition_id)
+    if model_constraints is None:
         raise AssertionError("Competition for {args.competition_id} not found")
 
-    competition.constraints.kwargs["use_cache"] = True
+    model_constraints.kwargs["use_cache"] = True
 
     print(f"Loading model for competition {args.competition_id}")
     load_model_perf = PerfMonitor("Eval: Load model")
     with load_model_perf.sample():
-        model = load_model(args.model_path, competition)
+        model = load_model(args.model_path, model_constraints)
     print(load_model_perf.summary_str())
 
     if not ModelUpdater.verify_model_satisfies_parameters(model):
@@ -103,8 +103,8 @@ def main():
     print(pull_data_perf.summary_str())
 
     print("Tokenizing cortex data")
-    tokenizer = ft.model.load_tokenizer(competition)
-    batches = cortex_data.tokenize(tokenizer, competition.constraints.sequence_length)
+    tokenizer = ft.model.load_tokenizer(model_constraints)
+    batches = cortex_data.tokenize(tokenizer, model_constraints.sequence_length)
 
     print("Calculating losses")
     compute_loss_perf = PerfMonitor("Eval: Compute loss")

--- a/scripts/upload_model.py
+++ b/scripts/upload_model.py
@@ -94,20 +94,18 @@ async def main(config: bt.config):
     HuggingFaceModelStore.assert_access_token_exists()
 
     # Get current model parameters
-    competition = competition_utils.get_competition(config.competition_id)
-    if competition is None:
+    model_constraints = competition_utils.get_model_constraints(config.competition_id)
+    if model_constraints is None:
         raise RuntimeError(
             f"Could not find current competition for id: {config.competition_id}"
         )
 
     # Load the model from disk and push it to the chain and Hugging Face.
-    model = ft.mining.load_local_model(
-        config.load_model_dir, competition.constraints.kwargs
-    )
+    model = ft.mining.load_local_model(config.load_model_dir, model_constraints.kwargs)
     await ft.mining.push(
         model,
         config.hf_repo_id,
-        competition.id,
+        config.competition_id,
         wallet,
         metadata_store=chain_metadata_store,
         update_repo_visibility=config.update_repo_visibility,
@@ -118,7 +116,7 @@ if __name__ == "__main__":
     # Parse and print configuration
     config = get_config()
     if config.list_competitions:
-        print(constants.COMPETITION_SCHEDULE)
+        print(constants.COMPETITION_SCHEDULE_BY_BLOCK)
     else:
         print(config)
         asyncio.run(main(config))

--- a/tests/competitions/test_utils.py
+++ b/tests/competitions/test_utils.py
@@ -1,36 +1,121 @@
 import unittest
 
-from transformers import LlamaForCausalLM
+import torch
+from transformers import (
+    BartForCausalLM,
+    FalconForCausalLM,
+    GemmaForCausalLM,
+    GPTNeoXForCausalLM,
+    LlamaForCausalLM,
+    MistralForCausalLM,
+    PhiForCausalLM,
+)
 
 from competitions.data import Competition, CompetitionId, ModelConstraints
-from competitions.utils import get_competition
+from competitions.utils import (
+    get_model_constraints,
+    get_competition_for_block,
+    get_competition_schedule_for_block,
+)
 
 unittest.util._MAX_LENGTH = 2000
 
 
 class TestUtils(unittest.TestCase):
-    def test_get_competition_valid_competition(self):
+    def test_get_model_constraints_valid_competition(self):
+        expected_constraints = ModelConstraints(
+            max_model_parameter_size=6_900_000_000,
+            sequence_length=4096,
+            allowed_architectures=[
+                MistralForCausalLM,
+                LlamaForCausalLM,
+                BartForCausalLM,
+                FalconForCausalLM,
+                GPTNeoXForCausalLM,
+                PhiForCausalLM,
+                GemmaForCausalLM,
+            ],
+            tokenizer="Xenova/gpt-4",
+            kwargs={
+                "torch_dtype": torch.bfloat16,
+                "attn_implementation": "flash_attention_2",
+            },
+        )
+
+        model_constraints = get_model_constraints(CompetitionId.SN9_MODEL)
+        self.assertEqual(model_constraints, expected_constraints)
+
+    def test_get_model_constraints_invalid_competition(self):
+        model_constraints = get_model_constraints(CompetitionId.COMPETITION_2)
+        self.assertIsNone(model_constraints)
+
+    def test_get_competition_for_block_valid_competition(self):
         expected_competition = Competition(
             id=CompetitionId.SN9_MODEL,
             constraints=ModelConstraints(
                 max_model_parameter_size=6_900_000_000,
                 sequence_length=4096,
-                allowed_architectures=[LlamaForCausalLM],
+                allowed_architectures=[
+                    MistralForCausalLM,
+                    LlamaForCausalLM,
+                    BartForCausalLM,
+                    FalconForCausalLM,
+                    GPTNeoXForCausalLM,
+                    PhiForCausalLM,
+                    GemmaForCausalLM,
+                ],
                 tokenizer="Xenova/gpt-4",
                 kwargs={
-                    "torch_dtype": "bfloat16",
+                    "torch_dtype": torch.bfloat16,
                     "attn_implementation": "flash_attention_2",
                 },
             ),
             reward_percentage=1.0,
         )
 
-        competition = get_competition(CompetitionId.SN9_MODEL)
+        competition = get_competition_for_block(CompetitionId.SN9_MODEL, 0)
         self.assertEqual(competition, expected_competition)
 
-    def test_get_competition_invalid_competition(self):
-        competition = get_competition(CompetitionId.COMPETITION_2)
+    def test_get_competition_for_block_invalid_competition(self):
+        competition = get_competition_for_block(CompetitionId.COMPETITION_2, 0)
         self.assertIsNone(competition)
+
+    def test_get_competition_for_block_invalid_block(self):
+        with self.assertRaises(Exception):
+            _ = get_competition_for_block(CompetitionId.SN9_MODEL, -1)
+
+    def test_get_competition_schedule_for_block_valid_block(self):
+        expected_competition_schedule = [
+            Competition(
+                id=CompetitionId.SN9_MODEL,
+                constraints=ModelConstraints(
+                    max_model_parameter_size=6_900_000_000,
+                    sequence_length=4096,
+                    allowed_architectures=[
+                        MistralForCausalLM,
+                        LlamaForCausalLM,
+                        BartForCausalLM,
+                        FalconForCausalLM,
+                        GPTNeoXForCausalLM,
+                        PhiForCausalLM,
+                        GemmaForCausalLM,
+                    ],
+                    tokenizer="Xenova/gpt-4",
+                    kwargs={
+                        "torch_dtype": torch.bfloat16,
+                        "attn_implementation": "flash_attention_2",
+                    },
+                ),
+                reward_percentage=1.0,
+            ),
+        ]
+
+        competition_schedule = get_competition_schedule_for_block(0)
+        self.assertEqual(competition_schedule, expected_competition_schedule)
+
+    def test_get_competition_schedule_for_block_invalid_block(self):
+        with self.assertRaises(Exception):
+            _ = get_competition_schedule_for_block(-1)
 
 
 if __name__ == "__main__":

--- a/tests/finetune/test_mining.py
+++ b/tests/finetune/test_mining.py
@@ -172,7 +172,9 @@ class TestMining(unittest.TestCase):
                 id=miner_1_model_id,
                 pt_model=model,
             ),
-            competition=competition_utils.get_competition(CompetitionId.SN9_MODEL),
+            model_constraints=competition_utils.get_model_constraints(
+                CompetitionId.SN9_MODEL
+            ),
         )
 
         # Verify that miner 1's model is loaded.

--- a/tests/model/test_model_updater.py
+++ b/tests/model/test_model_updater.py
@@ -132,7 +132,8 @@ class TestModelUpdater(unittest.TestCase):
         )
         asyncio.run(
             self.remote_store.upload_model(
-                model, competition_utils.get_competition(CompetitionId.SN9_MODEL)
+                model,
+                competition_utils.get_model_constraints(CompetitionId.SN9_MODEL),
             )
         )
 
@@ -229,7 +230,8 @@ class TestModelUpdater(unittest.TestCase):
         )
         asyncio.run(
             self.remote_store.upload_model(
-                model, competition_utils.get_competition(CompetitionId.SN9_MODEL)
+                model,
+                competition_utils.get_model_constraints(CompetitionId.SN9_MODEL),
             ),
         )
 
@@ -245,6 +247,7 @@ class TestModelUpdater(unittest.TestCase):
             model_metadata,
         )
 
+    # TODO: Create test for valid competition at too early of a block once added.
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Announcing Release 1.0.1.

This release includes a few fixes as well as refactoring to allow the competition schedule to change based on block.

This  is the first step in adding new competitions with different parameters and evaluation strategies. Stay tuned for more on this soon!

Subnet Improvements
- Competition Schedule is now based on the current block.
- Flash-attn requirement has been un-pinned. This should resolve issues with imports here. Please 
run python3 -m pip install flash-attn --upgrade to upgrade to the latest if this affected you.

Validator Improvements
- Fixed bug when outputting the step table log to wandb.