### PR TITLE
Reduce logging noise for expected "errors" in update loop

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -46,7 +46,7 @@ from competitions.competition_tracker import CompetitionTracker
 from competitions.data import CompetitionId
 from competitions import utils as competition_utils
 from model.model_tracker import ModelTracker
-from model.model_updater import ModelUpdater
+from model.model_updater import MinerMisconfiguredError, ModelUpdater
 from model.storage.chain.chain_model_metadata_store import ChainModelMetadataStore
 from model.storage.disk.disk_model_store import DiskModelStore
 from model.storage.hugging_face.hugging_face_model_store import HuggingFaceModelStore
@@ -495,9 +495,11 @@ class Validator:
                             )
                     else:
                         bt.logging.warning(
-                            f"Failed to find metadata for uid {uid} with hotkey {hotkey}"
+                            f"Failed to find metadata for uid {next_uid} with hotkey {hotkey}"
                         )
 
+            except MinerMisconfiguredError as e:
+                bt.logging.trace(e)
             except Exception as e:
                 bt.logging.error(f"Error in update loop: {e}")
 

--- a/tests/model/test_model_updater.py
+++ b/tests/model/test_model_updater.py
@@ -8,7 +8,7 @@ from competitions.data import CompetitionId
 from model import utils
 from model.data import Model, ModelId, ModelMetadata
 from model.model_tracker import ModelTracker
-from model.model_updater import ModelUpdater
+from model.model_updater import MinerMisconfiguredError, ModelUpdater
 from model.storage.disk.disk_model_store import DiskModelStore
 from tests.model.storage.fake_model_metadata_store import FakeModelMetadataStore
 from tests.model.storage.fake_remote_model_store import FakeRemoteModelStore
@@ -230,7 +230,7 @@ class TestModelUpdater(unittest.TestCase):
         self.remote_store.inject_mismatched_model(model_id_chain, model)
 
         # Assert we fail due to the hash mismatch between the model in remote store and the metadata on chain.
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(MinerMisconfiguredError) as context:
             asyncio.run(self.model_updater.sync_model(hotkey, curr_block=100_000))
 
         self.assertIn("Hash", str(context.exception))
@@ -276,7 +276,7 @@ class TestModelUpdater(unittest.TestCase):
         )
 
         # Assert we fail due to not meeting the competition parameters.
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(MinerMisconfiguredError) as context:
             asyncio.run(self.model_updater.sync_model(hotkey, curr_block=100_000))
 
         self.assertIn("does not satisfy parameters", str(context.exception))


### PR DESCRIPTION
We currently log twice if a we fail to sync a model for a UID. First as a trace log inside the ModelUpdater and then once as an error log in the exception handler of the update loop.

This changes that to just 1 trace log for expected errors due to miner misconfiguration