### PR TITLE
Remove flash attn.

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -73,7 +73,6 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         tokenizer="Xenova/gpt-4",
         kwargs={
             "torch_dtype": torch.bfloat16,
-            "attn_implementation": "flash_attention_2",
         },
         eval_block_delay=1200,  # ~4 hours.
     ),

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -39,13 +39,6 @@ cd finetuning
 python -m pip install -e .
 ```
 
-Note: flash-attn may not have their dependencies set up correctly. If you run into issues try installing those requirements separately first:
-```shell
-pip install packaging
-pip install wheel
-pip install torch
-```
-
 6. Make sure you've [created a Wallet](https://docs.bittensor.com/getting-started/wallets) and [registered a hotkey](https://docs.bittensor.com/subnets/register-and-participate).
 
 7. (Optional) Run a Subtensor instance:

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -61,9 +61,9 @@ It is important to note that this affects the game theoretics of the incentive l
 
 # System Requirements
 
-Validators will need enough disk space to store the model of every miner in the subnet. Each model (As of Jun 15th, 2024) is limited to 15 GB and 7B parameters, and the validator has cleanup logic to remove old models. It is recommended to have at least 3 TB of disk space.
+Validators will need enough disk space to store the model of every miner in the subnet. Each model (As of Jul 15th, 2024) is limited to 15 GB and 7B parameters, and the validator has cleanup logic to remove old models. It is recommended to have at least 3 TB of disk space.
 
-Validators will need enough processing power to evaluate their model. As of Jun 15th, 2024 it is required to have a GPU that supports [flash attention 2](https://github.com/Dao-AILab/flash-attention) with atleast 48 GB of VRAM and at least 38 TFLOPs for half precision (bfloat 16) operations.
+Validators will need enough processing power to evaluate their model. As of Jul 15th, 2024 it is required to have a GPU with atleast 48 GB of VRAM and at least 38 TFLOPs for half precision (bfloat 16) operations.
 
 # Getting Started
 
@@ -88,12 +88,6 @@ cd finetuning
 python -m pip install -e .
 ```
 
-Note: flash-attn may not have their dependencies set up correctly. If you run into issues try installing those requirements separately first:
-```shell
-pip install packaging
-pip install wheel
-pip install torch
-```
 
 5. Make sure you've [created a Wallet](https://docs.bittensor.com/getting-started/wallets) and [registered a hotkey](https://docs.bittensor.com/subnets/register-and-participate).
 

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -183,11 +183,6 @@ def miner_config():
         help="Number of samples trained on per epoch",
     )
     parser.add_argument(
-        "--attn_implementation",
-        default="flash_attention_2",
-        help="Implementation of attention to use",
-    )
-    parser.add_argument(
         "--netuid",
         type=str,
         default=constants.SUBNET_UID,

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -131,7 +131,6 @@ async def main(config: bt.config):
     kwargs["torch_dtype"] = (
         torch.bfloat16 if config.dtype == "bfloat16" else torch.float16
     )
-    kwargs["attn_implementation"] = config.attn_implementation
 
     # Init model.
     tokenizer = ft.model.load_tokenizer(model_constraints, cache_dir=config.model_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bittensor==6.9.3
-flash-attn
 huggingface_hub
 numpy==1.26.4
 python-dotenv

--- a/tests/competitions/test_utils.py
+++ b/tests/competitions/test_utils.py
@@ -39,7 +39,6 @@ class TestUtils(unittest.TestCase):
             eval_block_delay=1200,
             kwargs={
                 "torch_dtype": torch.bfloat16,
-                "attn_implementation": "flash_attention_2",
             },
         )
 
@@ -69,7 +68,6 @@ class TestUtils(unittest.TestCase):
                 eval_block_delay=1200,
                 kwargs={
                     "torch_dtype": torch.bfloat16,
-                    "attn_implementation": "flash_attention_2",
                 },
             ),
             reward_percentage=1.0,
@@ -106,7 +104,6 @@ class TestUtils(unittest.TestCase):
                     eval_block_delay=1200,
                     kwargs={
                         "torch_dtype": torch.bfloat16,
-                        "attn_implementation": "flash_attention_2",
                     },
                 ),
                 reward_percentage=1.0,


### PR DESCRIPTION
From testing against the current competition flash attention improves the inference speed by about 30%.

However given that we still have to load each model as well, the total improvement for evaluating a model is only about 20%. In absolute values, it is only about ~4.5 minutes to fully load and evaluate a model which is more than enough to get through all the models each epoch.

To simplify requirements and code, flash attn was also removed from the miner in this change, although they would be welcome to add it back in for their custom training code as the default mining code would not be competitive either way.



