### PR TITLE
Bump taoverse to 1.0.5.

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -19,13 +19,14 @@ from taoverse.model.competition.data import (
     ModelConstraints,
     NormValidationConstraints,
 )
+from taoverse.model.competition.epsilon import FixedEpsilon
 from competitions.data import CompetitionId
 
 # ---------------------------------
 # Project Constants.
 # ---------------------------------
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))
@@ -35,7 +36,7 @@ __spec_version__ = (
 
 # The version of the validator state. When incremented, causes validators
 # to start from a fresh state.
-VALIDATOR_STATE_VERSION = 2
+VALIDATOR_STATE_VERSION = 3
 
 # The validator WANDB project.
 WANDB_PROJECT = "finetuning"
@@ -85,6 +86,8 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
             norm_eps_soft_percent_threshold=0.15,
             norm_eps_hard=1000,
         ),
+        epsilon_func=FixedEpsilon(0.005),
+        max_bytes=15 * 1024 * 1024 * 1024,
     ),
 }
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -766,7 +766,7 @@ class Validator:
                     # Update the block this uid last updated their model.
                     uid_to_block[uid_i] = model_i_metadata.block
                     # Update the hf url for this model.
-                    uid_to_hf[uid_i] = self._get_hf_repo_name(model_i_metadata)
+                    uid_to_hf[uid_i] = model_utils.get_hf_repo_name(model_i_metadata)
 
                     # Get the model locally and evaluate its loss.
                     model_i = None
@@ -1162,11 +1162,6 @@ class Validator:
                 bt.logging.error(
                     f"Error in validator loop \n {e} \n {traceback.format_exc()}"
                 )
-
-    # TODO: Move to taoverse package.
-    def _get_hf_repo_name(self, model_metadata: ModelMetadata) -> str:
-        """Returns the Hugging Face repo name for the provided model metadata."""
-        return f"{model_metadata.id.namespace}/{model_metadata.id.name}"
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ safetensors
 torch==2.3.1
 transformers==4.41.2
 wandb==0.17.1
-taoverse==1.0.1
+taoverse==1.0.5


### PR DESCRIPTION
- Define a per competition max model size.
- Define a per competition Epsilon Func (currently unused)
- Use the taoverse repo name helper.
- Bump state version as there is a breaking change to the state of the model tracker.
- Bump overall version to 1.2.0 in preparation for upcoming release.