### PR TITLE
Add B7_MULTI_CHOICE competition.

### DIFF
--- a/competitions/data.py
+++ b/competitions/data.py
@@ -6,8 +6,7 @@ class CompetitionId(IntEnum):
 
     SN9_MODEL = 1
 
-    # Defined for tests. Will be repurposed later.
-    COMPETITION_2 = 2
+    B7_MULTI_CHOICE = 2
 
     # Overwrite the default __repr__, which doesn't work with
     # bt.logging for some unknown reason.

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -43,6 +43,8 @@ WANDB_PROJECT = "finetuning"
 WANDB_ENTITY = "rusticluftig"
 # The uid for this subnet.
 SUBNET_UID = 37
+# Minimum stake to get sample data from a validator.
+SAMPLE_VALI_MIN_STAKE = 100_000
 # The uid for the Cortex subnet.
 CORTEX_SUBNET_UID = 18
 # The Cortex.t validator WANDB project and filters
@@ -51,8 +53,6 @@ CORTEX_WANDB_TYPE = "validator"
 CORTEX_MAX_UIDS = 256
 CORTEX_MAX_AGE = dt.timedelta(hours=4)
 CORTEX_MIN_SCORE = 0.85
-# Minimum stake to get data from a cortex validator.
-CORTEX_MIN_STAKE = 100_000
 # The uid for the Prompting subnet.
 PROMPTING_SUBNET_UID = 1
 # The Prompting validator WANDB project and filters
@@ -60,8 +60,6 @@ PROMPTING_WANDB_PROJECT = "macrocosmos/prompting-validators"
 PROMPTING_MAX_AGE = dt.timedelta(hours=4)
 # Percentage of promping miners who must have gotten the question correct to include in the eval set.
 PROMPTING_MIN_CORRECT_MINERS = 0
-# Minimum stake to get data from a cortex validator.
-PROMPTING_MIN_STAKE = 100_000
 # Minimum stake to consider a validator when checking for miners with weights.
 WEIGHT_SYNC_VALI_MIN_STAKE = 100_000
 # Minimum percent of weight on a vali for a miner to be considered a top miner.

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -4,6 +4,12 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import torch
+from taoverse.model.competition.data import (
+    Competition,
+    ModelConstraints,
+    NormValidationConstraints,
+)
+from taoverse.model.competition.epsilon import FixedEpsilon, LinearDecay
 from transformers import (
     BartForCausalLM,
     FalconForCausalLM,
@@ -14,12 +20,6 @@ from transformers import (
     PhiForCausalLM,
 )
 
-from taoverse.model.competition.data import (
-    Competition,
-    ModelConstraints,
-    NormValidationConstraints,
-)
-from taoverse.model.competition.epsilon import FixedEpsilon
 from competitions.data import CompetitionId
 
 # ---------------------------------
@@ -53,6 +53,15 @@ CORTEX_MAX_AGE = dt.timedelta(hours=4)
 CORTEX_MIN_SCORE = 0.85
 # Minimum stake to get data from a cortex validator.
 CORTEX_MIN_STAKE = 100_000
+# The uid for the Prompting subnet.
+PROMPTING_SUBNET_UID = 1
+# The Prompting validator WANDB project and filters
+PROMPTING_WANDB_PROJECT = "macrocosmos/prompting-validators"
+PROMPTING_MAX_AGE = dt.timedelta(hours=4)
+# Percentage of promping miners who must have gotten the question correct to include in the eval set.
+PROMPTING_MIN_CORRECT_MINERS = 0
+# Minimum stake to get data from a cortex validator.
+PROMPTING_MIN_STAKE = 100_000
 # Minimum stake to consider a validator when checking for miners with weights.
 WEIGHT_SYNC_VALI_MIN_STAKE = 100_000
 # Minimum percent of weight on a vali for a miner to be considered a top miner.
@@ -63,7 +72,9 @@ ROOT_DIR = Path(__file__).parent.parent
 # The maximum bytes for the hugging face repo.
 MAX_HUGGING_FACE_BYTES: int = 15 * 1024 * 1024 * 1024
 # Defined model constraints by competition id to ensure they are constant across blocks.
-MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
+MODEL_CONSTRAINTS_BY_COMPETITION_ID_FIXED_EPSILON: Dict[
+    CompetitionId, ModelConstraints
+] = {
     CompetitionId.SN9_MODEL: ModelConstraints(
         max_model_parameter_size=6_900_000_000,
         sequence_length=4096,
@@ -90,6 +101,58 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         max_bytes=15 * 1024 * 1024 * 1024,
     ),
 }
+MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
+    CompetitionId.SN9_MODEL: ModelConstraints(
+        max_model_parameter_size=6_900_000_000,
+        sequence_length=4096,
+        allowed_architectures=[
+            MistralForCausalLM,
+            LlamaForCausalLM,
+            BartForCausalLM,
+            FalconForCausalLM,
+            GPTNeoXForCausalLM,
+            PhiForCausalLM,
+            GemmaForCausalLM,
+        ],
+        tokenizer="Xenova/gpt-4",
+        kwargs={
+            "torch_dtype": torch.bfloat16,
+        },
+        eval_block_delay=1200,  # ~4 hours.
+        norm_validation_constraints=NormValidationConstraints(
+            norm_eps_soft=200,
+            norm_eps_soft_percent_threshold=0.15,
+            norm_eps_hard=1000,
+        ),
+        epsilon_func=LinearDecay(0.005, 0.001, 7200 * 7),  # Decay over ~7 days.
+        max_bytes=15 * 1024 * 1024 * 1024,
+    ),
+    CompetitionId.B7_MULTI_CHOICE: ModelConstraints(
+        max_model_parameter_size=6_900_000_000,
+        sequence_length=4096,
+        allowed_architectures=[
+            MistralForCausalLM,
+            LlamaForCausalLM,
+            BartForCausalLM,
+            FalconForCausalLM,
+            GPTNeoXForCausalLM,
+            PhiForCausalLM,
+            GemmaForCausalLM,
+        ],
+        tokenizer="Xenova/gpt-4",
+        kwargs={
+            "torch_dtype": torch.bfloat16,
+        },
+        eval_block_delay=1200,  # ~4 hours.
+        norm_validation_constraints=NormValidationConstraints(
+            norm_eps_soft=200,
+            norm_eps_soft_percent_threshold=0.15,
+            norm_eps_hard=1000,
+        ),
+        epsilon_func=LinearDecay(0.005, 0.001, 7200 * 7),  # Decay over ~7 days.
+        max_bytes=15 * 1024 * 1024 * 1024,
+    ),
+}
 
 # Schedule of competitions by block.
 COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
@@ -98,11 +161,163 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
         [
             Competition(
                 CompetitionId.SN9_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID_FIXED_EPSILON[
+                    CompetitionId.SN9_MODEL
+                ],
                 1.0,
             )
         ],
-    )
+    ),
+    (
+        3790400,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.95,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.05,
+            ),
+        ],
+    ),
+    (
+        3794000,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.90,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.10,
+            ),
+        ],
+    ),
+    (
+        3797600,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.85,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.15,
+            ),
+        ],
+    ),
+    (
+        3801200,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.80,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.20,
+            ),
+        ],
+    ),
+    (
+        3804800,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.75,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.25,
+            ),
+        ],
+    ),
+    (
+        3808400,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.70,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.30,
+            ),
+        ],
+    ),
+    (
+        3812000,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.65,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.35,
+            ),
+        ],
+    ),
+    (
+        3815600,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.60,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.40,
+            ),
+        ],
+    ),
+    (
+        3819200,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.55,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.45,
+            ),
+        ],
+    ),
+    (
+        3822800,
+        [
+            Competition(
+                CompetitionId.SN9_MODEL,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
+                0.50,
+            ),
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.50,
+            ),
+        ],
+    ),
 ]
 
 for block_and_competitions in COMPETITION_SCHEDULE_BY_BLOCK:
@@ -131,6 +346,6 @@ model_retry_cadence = 300  # Roughly 1 hour
 # How frequently to check the models given weights by other large validators.
 scan_top_model_cadence = dt.timedelta(minutes=30)
 # validator eval batch min to keep for next loop.
-sample_min = 5
+sample_min = 2
 # We allow the sample_min per competition + 10 additional models to be held at any one time.
 updated_models_limit = sample_min * len(MODEL_CONSTRAINTS_BY_COMPETITION_ID) + 10

--- a/finetune/datasets/subnet/cortex_subset_loader.py
+++ b/finetune/datasets/subnet/cortex_subset_loader.py
@@ -413,7 +413,7 @@ class CortexSubsetLoader:
                 return
             except Exception:
                 attempt += 1
-                print(
+                bt.logging.warning(
                     f"Failed to fetch data. {traceback.format_exc()}, retrying. Attempt {attempt}/{retry_limit}"
                 )
                 if attempt < retry_limit:
@@ -456,3 +456,6 @@ class CortexSubsetLoader:
 
     def __iter__(self):
         return self.buffer.__iter__()
+
+    def __len__(self):
+        return len(self.buffer)

--- a/finetune/datasets/subnet/prompting_subset_loader.py
+++ b/finetune/datasets/subnet/prompting_subset_loader.py
@@ -1,0 +1,279 @@
+# The MIT License (MIT)
+# Copyright © 2023 Yuma Rao
+# Copyright © 2023 const
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+import datetime as dt
+import random
+import time
+import traceback
+import typing
+
+import bittensor as bt
+import torch
+import wandb
+from taoverse.utilities import utils
+from tqdm import tqdm
+from transformers import PreTrainedTokenizerBase
+from wandb.apis.public.history import HistoryScan
+
+import constants
+
+# Multiple choice answers for the prompting subnet.
+PROMPTING_SUBNET_CHOICES = ["A", "B", "C", "D"]
+
+# The date of the earliest wandb run to fetch.
+EARLIEST_DATE = dt.datetime(2024, 8, 29, tzinfo=dt.timezone.utc)
+
+
+class PromptingSubsetLoader:
+    def _get_filters(
+        self, use_latest_data, random_seed, validator_hotkeys
+    ) -> typing.Dict[str, typing.List[str]]:
+        filters_and = []
+        filters_or = []
+
+        if use_latest_data:
+            filters_and.append({"state": "running"})
+        else:
+            # If we're not fetching the latest data, then pick a random timepoint and iterate through runs
+            # from that timepoint. We do this instead of randomly picking runs across time because wandb's
+            # library processes runs serially. i.e., if you ask for run[N] it has to first fetch all N-1 runs.
+            # createdAt is is in UTC, so make sure we use UTC tz-aware datetimes.
+            random_date = utils.random_date(
+                EARLIEST_DATE,
+                dt.datetime.now(tz=dt.timezone.utc) - dt.timedelta(days=1),
+                random_seed,
+            )
+            filters_and.append(
+                {"createdAt": {"$gte": random_date.strftime("%Y-%m-%d %H:%M:%S")}}
+            )
+        if validator_hotkeys:
+            # 'IN' is not supported in the query language so we add a series of 'OR'.
+            for hotkey in validator_hotkeys:
+                filters_or.append({"config.HOTKEY_SS58": hotkey})
+
+        # Compose the complete dictionary of filters for the wandb call.
+        filters = {"$and": filters_and}
+        if len(filters_or) > 0:
+            filters["$or"] = filters_or
+
+        return filters
+
+    def __init__(
+        self,
+        use_latest_data: bool = False,
+        random_seed: typing.Optional[int] = None,
+        max_samples: int = 100,
+        steps: int = 300,
+        progress: bool = False,
+        retry_limit: int = 10,
+        page_size: int = 300,
+        prompting_project: str = constants.PROMPTING_WANDB_PROJECT,
+        max_run_age: typing.Optional[dt.timedelta] = None,
+        min_percent_correct: typing.Optional[float] = None,
+        validator_hotkeys: typing.Optional[typing.Set[str]] = None,
+    ):
+        """Loads prompt/response data from Subnet 1.
+
+        Args:
+            use_latest_data (bool, optional): When true, loads data from actively running runs and gets data from the run's latest step.
+            random_seed (typing.Optional[int], optional): Seed to use for all random operations.
+            max_samples (int, optional): The number of prompt/response samples to load.
+            steps (int, optional): Within a run, how many steps to look for samples.
+            progress (bool, optional): Whether to log progress of the data loading.
+            retry_limit (int, optional): How many times to retry, given any failure.
+            page_size (int, optional): The number of steps to fetch from a run at a time. Recommended to be >= steps.
+            prompting_project (_type_, optional): The wandb project used for subnet 1. Defaults to constants.PROMPTING_WANDB_PROJECT.
+            max_run_age (typing.Optional[dt.timedelta], optional): If set, only considers data from runs that were created within the past `max_run_age`
+            min_percent_correct (typing.Optional[float], optional): If set, only include prompt/responses at least "min_percent_correct" sn 1 miners answered correctly.
+            validator_hotkeys (typing.Optional[typing.Set[str]], optional): If provided, only considers data from one of these validators.
+        """
+        api = wandb.Api(timeout=100)
+
+        filters = self._get_filters(use_latest_data, random_seed, validator_hotkeys)
+
+        bt.logging.debug(f"Fetching runs using filters {filters}")
+
+        # Get the runs, oldest first.
+        runs = api.runs(prompting_project, filters, order="+created_at")
+
+        if random_seed is not None:
+            random.seed(random_seed)
+
+        retry_delay = 5  # Seconds to wait between retries
+        attempt = 0
+
+        while attempt < retry_limit:
+            try:
+                run_order = list(range(len(runs)))
+
+                # If we're only using the latest data, there are a small enough set of runs
+                # that it's okay for us to randomize the order. For cases where we're not using
+                # the latest data, we've already randomly picked data by choosing a random
+                # timestamp to get runs from.
+                if use_latest_data:
+                    random.shuffle(run_order)
+
+                self.buffer: typing.List[typing.Tuple[str, str]] = []
+                self.selected_samples: typing.Set[str] = set()
+
+                for run_index in tqdm(
+                    run_order, desc="Run", leave=False, disable=not progress
+                ):
+                    run = runs[run_index]
+                    # # Validator hotkeys are used to ensure the authenticity of the run.
+                    if validator_hotkeys:
+                        hotkey = run.config["HOTKEY_SS58"]
+                        # First check that the hotkey is in fact a desired validator hotkey.
+                        if hotkey not in validator_hotkeys:
+                            bt.logging.debug(
+                                f"Hotkey: {hotkey} does not match an expected validator for {run.id}."
+                            )
+                            continue
+
+                        signature = run.config["SIGNATURE"]
+                        # Then verify the signature using the hotkey.
+                        if not bt.Keypair(ss58_address=hotkey).verify(
+                            run.id, bytes.fromhex(signature)
+                        ):
+                            bt.logging.debug(
+                                f"Failed Signature: {signature} is not valid for {run.id}."
+                            )
+                            continue
+
+                    if use_latest_data:
+                        last_step: int = run.lastHistoryStep
+                    else:
+                        last_step = random.randint(
+                            min(steps, run.lastHistoryStep), run.lastHistoryStep
+                        )
+                    max_step = last_step + 1
+                    min_step = max(0, max_step - steps)
+
+                    history_scan = HistoryScan(
+                        run.client, run, min_step, max_step, page_size=page_size
+                    )
+                    while True:
+                        try:
+                            sample = next(history_scan)
+
+                            # Skip any samples older than max_run_age.
+                            if (
+                                max_run_age
+                                and dt.datetime.now()
+                                - dt.datetime.fromtimestamp(sample["_timestamp"])
+                                > max_run_age
+                            ):
+                                continue
+
+                            # Only check samples that are multiple choice based.
+                            if sample.get("task", "none") == "multi_choice":
+                                try:
+                                    # Check if a baseline threshold of SN1 miners answered the question correctly.
+                                    if min_percent_correct:  # min_percent_correct:
+                                        rewards = sample[
+                                            "MultiChoiceRewardModel_rewards"
+                                        ]
+                                        if isinstance(rewards, list) and isinstance(
+                                            rewards[0], (int, float)
+                                        ):
+                                            # 1 for correct, 0 for incorrect.
+                                            percent_correct = sum(rewards) / len(
+                                                rewards
+                                            )
+                                            if percent_correct < min_percent_correct:
+                                                continue
+
+                                    # If not found these get caught in the KeyError catch below.
+                                    challenge = sample["challenge"]
+                                    reference = sample["reference"]
+
+                                    if (
+                                        isinstance(challenge, str)
+                                        and isinstance(reference, str)
+                                        and reference in PROMPTING_SUBNET_CHOICES
+                                    ):
+                                        step = sample.get("_step", "Unknown")
+                                        run_step = f"{run.id}_{step}"
+                                        # Check that we haven't already seen this exact step to avoid duplicates.
+                                        if run_step not in self.selected_samples:
+                                            self.buffer.append((challenge, reference))
+                                            self.selected_samples.add(run_step)
+                                            if len(self.buffer) == max_samples:
+                                                return
+
+                                except KeyError:
+                                    pass
+                        except StopIteration:
+                            break
+
+                bt.logging.warning(
+                    f"Did not collect {max_samples}, only got {len(self.buffer)}"
+                )
+                return
+            except Exception:
+                attempt += 1
+                bt.logging.warning(
+                    f"Failed to fetch data. {traceback.format_exc()}, retrying. Attempt {attempt}/{retry_limit}"
+                )
+                if attempt < retry_limit:
+                    time.sleep(retry_delay)  # Wait before the next retry
+                else:
+                    bt.logging.error(
+                        "Maximum retry limit reached. Unable to fetch data."
+                    )
+                    raise
+
+    def tokenize(
+        self, tokenizer: PreTrainedTokenizerBase, sequence_length: int
+    ) -> typing.List[typing.Tuple[torch.Tensor, int]]:
+        # Each batch is a tokenized question + the chocies + the correct choice.
+        batches = []
+        # If truncation is necessary, truncate from the left to avoid cutting off the answer part.
+        tokenizer.truncation_side = "left"
+
+        for challenge, reference in self:
+            conversation = [
+                {"role": "user", "content": challenge},
+            ]
+            ids = tokenizer.apply_chat_template(
+                conversation,
+                truncation=True,
+                max_length=sequence_length,
+                add_generation_prompt=True,
+            )
+
+            batches.append(
+                (
+                    torch.stack([torch.tensor(ids)]),
+                    PROMPTING_SUBNET_CHOICES,
+                    reference,
+                )
+            )
+        return batches
+
+    def get_sample(self) -> typing.Tuple[str, str]:
+        return self.buffer[random.randint(0, len(self.buffer))]
+
+    def get_selected_sample_ids(self) -> typing.Set[str]:
+        """Returns the set of run_id steps that data was selected from."""
+        return self.selected_samples
+
+    def __iter__(self):
+        return self.buffer.__iter__()
+
+    def __len__(self):
+        return len(self.buffer)

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -53,6 +53,18 @@ def validator_config():
         help="Number of most recent Cortex samples to eval against",
     )
     parser.add_argument(
+        "--latest_prompting_steps",
+        type=int,
+        default=500,  # Sample more steps since prompting runs this less frequently.
+        help="Number of most recent Prompting steps to sample data from",
+    )
+    parser.add_argument(
+        "--latest_prompting_samples",
+        type=int,
+        default=100,
+        help="Number of most recent Prompting samples to eval against",
+    )
+    parser.add_argument(
         "--sample_min",
         type=int,
         default=constants.sample_min,

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -61,7 +61,7 @@ def validator_config():
     parser.add_argument(
         "--latest_prompting_samples",
         type=int,
-        default=100,
+        default=200,
         help="Number of most recent Prompting samples to eval against",
     )
     parser.add_argument(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -812,7 +812,7 @@ class Validator:
             # Only pull from validators meeting a minimum stake threshold.
             with self.cortex_metagraph_lock:
                 vali_uids = metagraph_utils.get_high_stake_validators(
-                    self.cortex_metagraph, constants.CORTEX_MIN_STAKE
+                    self.cortex_metagraph, constants.SAMPLE_VALI_MIN_STAKE
                 )
                 vali_hotkeys = set(
                     [self.cortex_metagraph.hotkeys[uid] for uid in vali_uids]
@@ -831,7 +831,7 @@ class Validator:
         elif competition.id == CompetitionId.B7_MULTI_CHOICE:
             with self.prompting_metagraph_lock:
                 vali_uids = metagraph_utils.get_high_stake_validators(
-                    self.prompting_metagraph, constants.PROMPTING_MIN_STAKE
+                    self.prompting_metagraph, constants.SAMPLE_VALI_MIN_STAKE
                 )
                 vali_hotkeys = set(
                     [self.prompting_metagraph.hotkeys[uid] for uid in vali_uids]

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -926,7 +926,7 @@ class Validator:
                                     batches,
                                     self.config.device,
                                 ),
-                                ttl=360,
+                                ttl=400,
                                 mode="spawn",
                             )
                     elif competition.id == CompetitionId.B7_MULTI_CHOICE:
@@ -951,7 +951,7 @@ class Validator:
                                     batches,
                                     self.config.device,
                                 ),
-                                ttl=360,
+                                ttl=400,
                                 mode="spawn",
                             )
                     else:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -72,6 +72,7 @@ import constants
 import finetune as ft
 from competitions.data import CompetitionId
 from finetune.datasets.subnet.cortex_subset_loader import CortexSubsetLoader
+from finetune.datasets.subnet.prompting_subset_loader import PromptingSubsetLoader
 from model.retry import should_retry_model
 from neurons import config as neuron_config
 
@@ -93,8 +94,8 @@ class PerUIDEvalState:
     # The hugging face repo name.
     repo_name: str = "Unknown"
 
-    # The losses per batch.
-    losses: typing.List[float] = dataclasses.field(default=None)
+    # The deviations per batch. Currently either losses or percent of questions wrong.
+    deviations: typing.List[float] = dataclasses.field(default=None)
 
 
 class Validator:
@@ -146,6 +147,7 @@ class Validator:
             self.dataset_subtensor,
             config={
                 constants.CORTEX_SUBNET_UID: dt.timedelta(hours=12).total_seconds(),
+                constants.PROMPTING_SUBNET_UID: dt.timedelta(hours=12).total_seconds(),
             },
         )
 
@@ -155,6 +157,7 @@ class Validator:
         # Create metagraph locks to avoid cross thread access issues in the update loop.
         self.metagraph_lock = threading.RLock()
         self.cortex_metagraph_lock = threading.RLock()
+        self.prompting_metagraph_lock = threading.RLock()
 
         # Get initial metagraphs.
         self.metagraph: bt.metagraph = self.subnet_metagraph_syncer.get_metagraph(
@@ -163,9 +166,13 @@ class Validator:
         self.cortex_metagraph: bt.metagraph = (
             self.dataset_metagraph_syncer.get_metagraph(constants.CORTEX_SUBNET_UID)
         )
+        self.prompting_metagraph: bt.metagraph = (
+            self.dataset_metagraph_syncer.get_metagraph(constants.PROMPTING_SUBNET_UID)
+        )
 
         bt.logging.info(f"Metagraph: {self.metagraph}.")
         bt.logging.info(f"Cortex Metagraph: {self.cortex_metagraph}.")
+        bt.logging.info(f"Prompting Metagraph: {self.prompting_metagraph}.")
 
         # Register a listener for the subnet and dataset metagraph syncers.
         self.subnet_metagraph_syncer.register_listener(
@@ -174,7 +181,7 @@ class Validator:
         )
         self.dataset_metagraph_syncer.register_listener(
             self._on_dataset_metagraph_updated,
-            netuids=[constants.CORTEX_SUBNET_UID],
+            netuids=[constants.CORTEX_SUBNET_UID, constants.PROMPTING_SUBNET_UID],
         )
 
         # Dont check registration status if offline.
@@ -731,8 +738,11 @@ class Validator:
     def _on_dataset_metagraph_updated(self, metagraph: bt.metagraph, netuid: int):
         """Processes an update to the metagraph for the dataset subnets."""
         if netuid == constants.CORTEX_SUBNET_UID:
-            with self.cortex_metagraph:
+            with self.cortex_metagraph_lock:
                 self.cortex_metagraph = copy.deepcopy(metagraph)
+        elif netuid == constants.PROMPTING_SUBNET_UID:
+            with self.prompting_metagraph_lock:
+                self.prompting_metagraph = copy.deepcopy(metagraph)
         else:
             bt.logging.error(
                 f"Unexpected subnet uid in dataset metagraph syncer: {netuid}"
@@ -756,11 +766,11 @@ class Validator:
         Executes a step in the evaluation process of models. This function performs several key tasks:
             1. Identifies valid models for evaluation (top 5 from last run + newly updated models).
             2. Generates random pages for evaluation and prepares batches for each page from the dataset.
-            3. Computes the scoring for each model based on the losses incurred on the evaluation batches.
+            3. Computes the scoring for each model based on the deviations found on the evaluation batches.
             4. Calculates wins and win rates for each model to determine their performance relative to others.
             5. Updates the weights of each model based on their performance and applies a softmax normalization.
             6. Implements a blacklist mechanism to remove underperforming models from the evaluation set.
-            7. Logs all relevant data for the step, including model IDs, pages, batches, wins, win rates, and losses.
+            7. Logs all relevant data for the step, including model IDs, pages, batches, wins, win rates, and deviations.
         """
 
         block = self._get_current_block()
@@ -793,35 +803,67 @@ class Validator:
                 time.sleep(300)
             return
 
-        # Pull the latest data from Cortex
-        # Only pull from validators meeting a minimum stake threshold.
-        with self.cortex_metagraph_lock:
-            vali_uids = metagraph_utils.get_high_stake_validators(
-                self.cortex_metagraph, constants.CORTEX_MIN_STAKE
-            )
-            vali_hotkeys = set(
-                [self.cortex_metagraph.hotkeys[uid] for uid in vali_uids]
+        # Pull the latest sample data based on the competition.
+        sample_data = None
+        load_data_perf = PerfMonitor("Eval: Load data")
+
+        if competition.id == CompetitionId.SN9_MODEL:
+            # Pull the latest data from Cortex
+            # Only pull from validators meeting a minimum stake threshold.
+            with self.cortex_metagraph_lock:
+                vali_uids = metagraph_utils.get_high_stake_validators(
+                    self.cortex_metagraph, constants.CORTEX_MIN_STAKE
+                )
+                vali_hotkeys = set(
+                    [self.cortex_metagraph.hotkeys[uid] for uid in vali_uids]
+                )
+
+            with load_data_perf.sample():
+                sample_data = CortexSubsetLoader(
+                    use_latest_data=True,
+                    random_seed=random.randint(0, sys.maxsize),
+                    max_samples=self.config.latest_cortex_samples,
+                    steps=self.config.latest_cortex_steps,
+                    page_size=self.config.latest_cortex_steps,
+                    max_run_age=constants.CORTEX_MAX_AGE,
+                    validator_hotkeys=vali_hotkeys,
+                )
+        elif competition.id == CompetitionId.B7_MULTI_CHOICE:
+            with self.prompting_metagraph_lock:
+                vali_uids = metagraph_utils.get_high_stake_validators(
+                    self.prompting_metagraph, constants.PROMPTING_MIN_STAKE
+                )
+                vali_hotkeys = set(
+                    [self.prompting_metagraph.hotkeys[uid] for uid in vali_uids]
+                )
+
+            with load_data_perf.sample():
+                sample_data = PromptingSubsetLoader(
+                    use_latest_data=True,
+                    random_seed=random.randint(0, sys.maxsize),
+                    max_samples=self.config.latest_prompting_samples,
+                    steps=self.config.latest_prompting_steps,
+                    page_size=self.config.latest_prompting_steps,
+                    max_run_age=constants.PROMPTING_MAX_AGE,
+                    min_percent_correct=constants.PROMPTING_MIN_CORRECT_MINERS,
+                    validator_hotkeys=vali_hotkeys,
+                )
+        else:
+            raise ValueError(
+                f"Competition id: {competition.id} has no sample loading logic specified."
             )
 
-        cortex_data = None
-        load_data_perf = PerfMonitor("Eval: Load data")
-        with load_data_perf.sample():
-            cortex_data = CortexSubsetLoader(
-                use_latest_data=True,
-                random_seed=random.randint(0, sys.maxsize),
-                max_samples=self.config.latest_cortex_samples,
-                steps=self.config.latest_cortex_steps,
-                page_size=self.config.latest_cortex_steps,
-                max_run_age=constants.CORTEX_MAX_AGE,
-                validator_hotkeys=vali_hotkeys,
-            )
+        if not sample_data:
+            bt.logging.error("Failed to load sample data. Skipping evaluation.")
+            return
 
         # Tokenize the data into batches for use in evaluation.
         # If custom tokenizers are allowed this will need to be done on a per uid basis instead.
         tokenizer = ft.model.load_tokenizer(
             competition.constraints, cache_dir=self.config.model_dir
         )
-        batches = cortex_data.tokenize(
+        # Note that the formatting of batches changes depending on where the sample data is obtained.
+        batches = sample_data.tokenize(
             tokenizer, competition.constraints.sequence_length
         )
 
@@ -829,16 +871,17 @@ class Validator:
         kwargs = competition.constraints.kwargs.copy()
         kwargs["use_cache"] = True
 
-        # Compute model losses on batches.
-        bt.logging.debug(f"Computing losses on {uids} for competition {competition.id}")
+        # Compute model deviations on batches.
+        bt.logging.debug(
+            f"Computing deviations on {uids} for competition {competition.id}"
+        )
         uid_to_state = defaultdict(PerUIDEvalState)
 
         load_model_perf = PerfMonitor("Eval: Load model")
-        compute_loss_perf = PerfMonitor("Eval: Compute loss")
+        compute_deviation_perf = PerfMonitor("Eval: Compute deviation")
 
         for uid_i in uids:
-            losses: typing.List[float] = [math.inf for _ in range(len(batches))]
-            sample: typing.Optional[typing.Tuple[str, str]] = None
+            deviations: typing.List[float] = [math.inf for _ in range(len(batches))]
 
             # Check that the model is in the tracker.
             with self.metagraph_lock:
@@ -866,92 +909,80 @@ class Validator:
                         model_i_metadata
                     )
 
-                    # Get the model locally and evaluate its loss.
+                    # Get the model locally and evaluate its deviation.
                     model_i = None
                     with load_model_perf.sample():
                         model_i = self.local_store.retrieve_model(
                             hotkey, model_i_metadata.id, kwargs
                         )
 
-                    with compute_loss_perf.sample():
-                        # Run each computation in a subprocess so that the GPU is reset between each model.
-                        losses = utils.run_in_subprocess(
-                            functools.partial(
-                                ft.validation.compute_losses,
-                                model_i.pt_model,
-                                batches,
-                                self.config.device,
-                            ),
-                            ttl=360,
-                            mode="spawn",
-                        )
-
-                    if self.config.do_sample:
-                        try:
-                            prompt, truth = cortex_data.get_sample()
-                            conversation = [{"role": "user", "content": prompt}]
-                            input_ids = tokenizer.apply_chat_template(
-                                conversation,
-                                truncation=True,
-                                return_tensors="pt",
-                                max_length=competition.constraints.sequence_length,
-                                add_generation_prompt=True,
-                            )
-                            generation_config = GenerationConfig(
-                                max_length=competition.constraints.sequence_length,
-                                do_sample=True,
-                                temperature=0.8,
-                                top_p=0.95,
-                                top_k=40,
-                                repetition_penalty=1.1,
-                                eos_token_id=tokenizer.eos_token_id,
-                                pad_token_id=tokenizer.eos_token_id,
-                            )
-                            # Run each generation in a subprocess so that the GPU is reset between each model.
-                            response = utils.run_in_subprocess(
+                    if competition.id == CompetitionId.SN9_MODEL:
+                        with compute_deviation_perf.sample():
+                            # Run each computation in a subprocess so that the GPU is reset between each model.
+                            deviations = utils.run_in_subprocess(
                                 functools.partial(
-                                    ft.validation.generate_output,
+                                    ft.validation.compute_losses,
                                     model_i.pt_model,
-                                    input_ids,
-                                    generation_config,
+                                    batches,
                                     self.config.device,
-                                    tokenizer,
                                 ),
                                 ttl=360,
                                 mode="spawn",
                             )
-                            sample = (prompt, response, truth)
-                            bt.logging.success(
-                                f"Generated sample for uid: {uid_i} Prompt: {sample[0]}\n\nResponse: {sample[1]}\n\nTruth: {sample[2]}"
+                    elif competition.id == CompetitionId.B7_MULTI_CHOICE:
+                        compute_generation_config = GenerationConfig(
+                            max_new_tokens=20,
+                            do_sample=True,
+                            temperature=0.8,
+                            top_p=0.95,
+                            top_k=40,
+                            repetition_penalty=1.1,
+                            eos_token_id=tokenizer.eos_token_id,
+                            pad_token_id=tokenizer.eos_token_id,
+                        )
+                        with compute_deviation_perf.sample():
+                            # Run each computation in a subprocess so that the GPU is reset between each model.
+                            deviations = utils.run_in_subprocess(
+                                functools.partial(
+                                    ft.validation.compute_multiple_choice_deviation,
+                                    model_i.pt_model,
+                                    tokenizer,
+                                    compute_generation_config,
+                                    batches,
+                                    self.config.device,
+                                ),
+                                ttl=360,
+                                mode="spawn",
                             )
-                        except Exception as e:
-                            bt.logging.error(
-                                f"Error in eval loop during sample generation: {e}."
-                            )
-                            traceback.print_exc()  # Print the stack trace
+                    else:
+                        raise ValueError(
+                            f"Competition id: {competition.id} has no evaluation logic specified."
+                        )
 
                     del model_i
                 except Exception as e:
                     bt.logging.error(
-                        f"Error in eval loop: {e}. Setting losses for uid: {uid_i} to infinity."
+                        f"Error in eval loop: {e}. Setting deviations for uid: {uid_i} to infinity."
                     )
             else:
                 bt.logging.debug(
                     f"Unable to load the model metadata for {uid_i} or it belongs to another competition. Setting loss to infinity for this competition."
                 )
 
-            average_model_loss = sum(losses) / len(losses)
-            uid_to_state[uid_i].losses = losses
+            average_model_deviation = sum(deviations) / len(deviations)
+            uid_to_state[uid_i].deviations = deviations
             bt.logging.trace(
-                f"Computed model losses for uid: {uid_i} with average loss: {average_model_loss}"
+                f"Computed model deviations for uid: {uid_i} with average deviation: {average_model_deviation}"
             )
 
         # Compute wins and win rates per uid.
-        losses_per_uid = {uid: state.losses for uid, state in uid_to_state.items()}
+        deviations_per_uid = {
+            uid: state.deviations for uid, state in uid_to_state.items()
+        }
         uid_to_block = {uid: state.block for uid, state in uid_to_state.items()}
         wins, win_rate = ft.validation.compute_wins(
             uids,
-            losses_per_uid,
+            deviations_per_uid,
             batches,
             uid_to_block,
             competition.constraints.epsilon_func,
@@ -1017,7 +1048,7 @@ class Validator:
         # Log the performance of the eval loop.
         bt.logging.debug(load_data_perf.summary_str())
         bt.logging.debug(load_model_perf.summary_str())
-        bt.logging.debug(compute_loss_perf.summary_str())
+        bt.logging.debug(compute_deviation_perf.summary_str())
 
         # Log to screen and wandb.
         self.log_step(
@@ -1026,12 +1057,12 @@ class Validator:
             uids,
             uid_to_state,
             self._get_uids_to_competition_ids(),
-            list(cortex_data.get_selected_sample_ids()),
+            list(sample_data.get_selected_sample_ids()),
             wins,
             win_rate,
             tracker_competition_weights,
             load_model_perf,
-            compute_loss_perf,
+            compute_deviation_perf,
             load_data_perf,
         )
 
@@ -1078,26 +1109,28 @@ class Validator:
             curr_block (int): The current block.
             uid_to_state (typing.Dict[int, PerUIDEvalState]): A dictionary mapping uids to their eval state.
         """
-        top_model_loss = self._compute_avg_loss(uid_to_state[top_uid].losses)
+        top_model_deviation = self._compute_avg_deviation(
+            uid_to_state[top_uid].deviations
+        )
         for _, state in uid_to_state.items():
             self.model_tracker.on_model_evaluated(
                 state.hotkey,
                 EvalResult(
                     block=curr_block,
-                    score=self._compute_avg_loss(state.losses),
+                    score=self._compute_avg_deviation(state.deviations),
                     winning_model_block=uid_to_state[top_uid].block,
-                    winning_model_score=top_model_loss,
+                    winning_model_score=top_model_deviation,
                 ),
             )
 
-    def _compute_avg_loss(self, losses: typing.List[float]) -> float:
-        """Safely computes the average loss from a list of losses.
+    def _compute_avg_deviation(self, deviations: typing.List[float]) -> float:
+        """Safely computes the average deviation from a list of deviations.
         Args:
-            losses (typing.List[float]): A list of losses.
+            deviations (typing.List[float]): A list of deviations.
         Returns:
-            float: The average loss.
+            float: The average deviation.
         """
-        return sum(losses) / len(losses) if losses else math.inf
+        return sum(deviations) / len(deviations) if deviations else math.inf
 
     def log_step(
         self,
@@ -1111,7 +1144,7 @@ class Validator:
         win_rate: typing.Dict[int, float],
         competition_weights: torch.Tensor,
         load_model_perf: PerfMonitor,
-        compute_loss_perf: PerfMonitor,
+        compute_deviation_perf: PerfMonitor,
         load_data_perf: PerfMonitor,
     ):
         """Logs the results of the step to the console and wandb (if enabled)."""
@@ -1130,7 +1163,9 @@ class Validator:
                 "block": uid_to_state[uid].block,
                 "hf": uid_to_state[uid].repo_name,
                 "competition_id": int(competition.id),
-                "average_loss": self._compute_avg_loss(uid_to_state[uid].losses),
+                "average_loss": self._compute_avg_deviation(
+                    uid_to_state[uid].deviations
+                ),  # Keep the log here as loss to avoid breaking the leaderboard.
                 "epsilon_adv": competition.constraints.epsilon_func.compute_epsilon(
                     current_block, uid_to_state[uid].block
                 ),
@@ -1141,7 +1176,7 @@ class Validator:
         table = Table(title="Step", expand=True)
         table.add_column("uid", justify="right", style="cyan", no_wrap=True)
         table.add_column("hf", style="magenta", overflow="fold")
-        table.add_column("avg_loss", style="magenta", overflow="fold")
+        table.add_column("avg_deviation", style="magenta", overflow="fold")
         table.add_column("epsilon_adv", style="magenta", overflow="fold")
         table.add_column("win_rate", style="magenta", overflow="fold")
         table.add_column("total_weight", style="magenta", overflow="fold")
@@ -1231,10 +1266,10 @@ class Validator:
                     "P90": load_model_perf.percentile(90),
                 },
                 "compute_model_perf": {
-                    "min": compute_loss_perf.min(),
-                    "median": compute_loss_perf.median(),
-                    "max": compute_loss_perf.max(),
-                    "P90": compute_loss_perf.percentile(90),
+                    "min": compute_deviation_perf.min(),
+                    "median": compute_deviation_perf.median(),
+                    "max": compute_deviation_perf.max(),
+                    "P90": compute_deviation_perf.percentile(90),
                 },
                 "load_data_perf": {
                     "min": load_data_perf.min(),

--- a/scripts/model_validation.py
+++ b/scripts/model_validation.py
@@ -7,30 +7,39 @@ import math
 import random
 import sys
 
-from taoverse.model.competition.data import Competition
+from taoverse.model.competition import utils as competition_utils
 from taoverse.model.data import Model, ModelId
 from taoverse.model.model_updater import ModelUpdater
 from taoverse.utilities.enum_action import IntEnumAction
 from taoverse.utilities.perf_monitor import PerfMonitor
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig
 
 import constants
 import finetune as ft
 from competitions.data import CompetitionId
 from finetune.datasets.subnet.cortex_subset_loader import CortexSubsetLoader
-from finetune.validation import compute_losses
+from finetune.datasets.subnet.prompting_subset_loader import PromptingSubsetLoader
+from finetune.validation import compute_losses, compute_multiple_choice_deviation
 
 
-def load_model(model_path, competition: Competition) -> Model:
+def load_model(model_path, competition_id, allow_remote_code, kwargs) -> Model:
     model_id = ModelId(
-        namespace="namespace", name="name", competition_id=competition.id
+        namespace="namespace", name="name", competition_id=competition_id
     )
-    pt_model = AutoModelForCausalLM.from_pretrained(
-        pretrained_model_name_or_path=model_path,
-        local_files_only=True,
-        use_safetensors=True,
-        **competition.constraints.kwargs,
-    )
+    if allow_remote_code:
+        pt_model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path=model_path,
+            trust_remote_code=True,
+            use_safetensors=True,
+            **kwargs,
+        )
+    else:
+        pt_model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path=model_path,
+            local_files_only=True,
+            use_safetensors=True,
+            **kwargs,
+        )
 
     return Model(id=model_id, pt_model=pt_model)
 
@@ -47,16 +56,34 @@ def main():
         help="Device name.",
     )
     parser.add_argument(
+        "--random_seed",
+        type=int,
+        default=0,
+        help="Random seed to use while loading data. If 0 then randomize.",
+    )
+    parser.add_argument(
         "--latest_cortex_steps",
         type=int,
         default=5,
-        help="Number of most recent Cortex steps to sample data from",
+        help="Number of most recent cortex steps to sample data from",
     )
     parser.add_argument(
         "--latest_cortex_samples",
         type=int,
         default=400,
-        help="Number of most recent Cortex samples to eval against",
+        help="Number of most recent cortex samples to eval against",
+    )
+    parser.add_argument(
+        "--latest_prompting_steps",
+        type=int,
+        default=500,
+        help="Number of most recent prompting steps to sample data from",
+    )
+    parser.add_argument(
+        "--latest_prompting_samples",
+        type=int,
+        default=100,
+        help="Number of most recent prompting samples to eval against",
     )
     parser.add_argument(
         "--competition_id",
@@ -66,58 +93,144 @@ def main():
         help="competition to mine for (use --list-competitions to get all competitions)",
     )
     parser.add_argument(
+        "--allow_remote_code",
+        action="store_true",
+        help="If a remote code should be allowed",
+    )
+    parser.add_argument(
+        "--skip_constraints_check",
+        action="store_true",
+        help="If the competition constraints check should be skipped",
+    )
+    parser.add_argument(
         "--list_competitions", action="store_true", help="Print out all competitions"
+    )
+    parser.add_argument(
+        "--tokenizer_override",
+        action="store_true",
+        help="If a custom tokenizer should be used rather than the competition one",
+    )
+    parser.add_argument(
+        "--tokenizer",
+        type=str,
+        default="Xenova/gpt-4",
+        help="Tokenizer",
+    )
+    parser.add_argument(
+        "--comp_block",
+        type=int,
+        default=9999999999,
+        help="Block to lookup competition id from.",
     )
     args = parser.parse_args()
     if args.list_competitions:
         print(constants.COMPETITION_SCHEDULE_BY_BLOCK)
         return
 
-    model_constraints = constants.MODEL_CONSTRAINTS_BY_COMPETITION_ID.get(
-        args.competition_id, None
+    competition = competition_utils.get_competition_for_block(
+        args.competition_id,
+        args.comp_block,
+        constants.COMPETITION_SCHEDULE_BY_BLOCK,
     )
 
-    if model_constraints is None:
-        raise AssertionError("Competition for {args.competition_id} not found")
-
-    model_constraints.kwargs["use_cache"] = True
+    kwargs = competition.constraints.kwargs.copy()
+    kwargs["use_cache"] = True
 
     print(f"Loading model for competition {args.competition_id}")
     load_model_perf = PerfMonitor("Eval: Load model")
     with load_model_perf.sample():
-        model = load_model(args.model_path, model_constraints)
+        model = load_model(
+            args.model_path, competition.id, args.allow_remote_code, kwargs
+        )
     print(load_model_perf.summary_str())
 
-    if not ModelUpdater.verify_model_satisfies_parameters(model, model_constraints):
-        print("Model does not satisfy competition parameters!!!")
-        return
+    if not args.skip_constraints_check:
+        if not ModelUpdater.verify_model_satisfies_parameters(
+            model, competition.constraints
+        ):
+            print("Model does not satisfy competition parameters!!!")
+            return
 
-    print("Getting latest Cortex data")
     pull_data_perf = PerfMonitor("Eval: Pull data")
+    sample_data = None
 
-    with pull_data_perf.sample():
-        cortex_data = CortexSubsetLoader(
-            use_latest_data=True,
-            random_seed=random.randint(0, sys.maxsize),
-            max_samples=args.latest_cortex_samples,
-            steps=args.latest_cortex_steps,
-            page_size=args.latest_cortex_steps,
+    seed = args.random_seed if args.random_seed else random.randint(0, sys.maxsize)
+
+    if args.competition_id == CompetitionId.SN9_MODEL:
+        print("Getting latest sample data from cortex.")
+        with pull_data_perf.sample():
+            sample_data = CortexSubsetLoader(
+                use_latest_data=True,
+                random_seed=seed,
+                max_samples=args.latest_cortex_samples,
+                steps=args.latest_cortex_steps,
+                page_size=args.latest_cortex_steps,
+            )
+    elif args.competition_id == CompetitionId.B7_MULTI_CHOICE:
+        print("Getting latest sample data from prompting.")
+        with pull_data_perf.sample():
+            sample_data = PromptingSubsetLoader(
+                use_latest_data=True,
+                random_seed=seed,
+                max_samples=args.latest_prompting_samples,
+                steps=args.latest_prompting_steps,
+                page_size=args.latest_prompting_steps,
+                min_percent_correct=constants.PROMPTING_MIN_CORRECT_MINERS,
+            )
+    else:
+        print(
+            f"Competition id: {args.competition_id} has no sample loading logic specified."
         )
+        return
     print(pull_data_perf.summary_str())
 
-    print("Tokenizing cortex data")
-    tokenizer = ft.model.load_tokenizer(model_constraints)
-    batches = cortex_data.tokenize(tokenizer, model_constraints.sequence_length)
+    print("Tokenizing sample data")
+    if args.tokenizer_override:
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.tokenizer, trust_remote_code=args.allow_remote_code
+        )
+    else:
+        tokenizer = ft.model.load_tokenizer(competition.constraints)
+    batches = sample_data.tokenize(tokenizer, competition.constraints.sequence_length)
 
-    print("Calculating losses")
-    compute_loss_perf = PerfMonitor("Eval: Compute loss")
-    with compute_loss_perf.sample():
-        losses = compute_losses(model.pt_model, batches, device=args.device)
-    print(compute_loss_perf.summary_str())
+    print("Calculating deviations")
+    compute_deviation_perf = PerfMonitor("Eval: Compute deviation")
 
-    average_model_loss = sum(losses) / len(losses) if len(losses) > 0 else math.inf
+    if args.competition_id == CompetitionId.SN9_MODEL:
+        with compute_deviation_perf.sample():
+            deviations = compute_losses(model.pt_model, batches, device=args.device)
+    elif args.competition_id == CompetitionId.B7_MULTI_CHOICE:
+        generation_config = GenerationConfig(
+            max_new_tokens=20,
+            do_sample=True,
+            temperature=0.8,
+            top_p=0.95,
+            top_k=40,
+            repetition_penalty=1.1,
+            eos_token_id=tokenizer.eos_token_id,
+            pad_token_id=tokenizer.eos_token_id,
+        )
+        with compute_deviation_perf.sample():
+            deviations = compute_multiple_choice_deviation(
+                model.pt_model,
+                tokenizer,
+                generation_config,
+                batches,
+                device=args.device,
+            )
+    else:
+        print(
+            f"Competition id: {args.competition_id} has no evaluation logic specified."
+        )
+        return
 
-    print(f"The average model loss for {args.model_path} is {average_model_loss}")
+    print(compute_deviation_perf.summary_str())
+
+    average_model_deviation = (
+        sum(deviations) / len(deviations) if len(deviations) > 0 else math.inf
+    )
+
+    print(f"The average deviation for {args.model_path} is {average_model_deviation}")
 
 
 if __name__ == "__main__":

--- a/tests/finetune/test_graph.py
+++ b/tests/finetune/test_graph.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import unittest
 from unittest import mock
@@ -9,12 +8,11 @@ from taoverse.model.data import ModelId
 
 from competitions.data import CompetitionId
 from finetune import graph
-from tests.model.storage.fake_model_metadata_store import \
-    FakeModelMetadataStore
+from tests.model.storage.fake_model_metadata_store import FakeModelMetadataStore
 
 
 class TestMining(unittest.TestCase):
-    
+
     def _create_metagraph(self) -> bt.metagraph:
         mock_metagraph = mock.MagicMock()
         mock_metagraph.n = 10
@@ -23,35 +21,88 @@ class TestMining(unittest.TestCase):
         )
         mock_metagraph.hotkeys = [f"hotkey_{i}" for i in range(10)]
         return mock_metagraph
-    
+
     def test_best_uid(self):
         """Tests that the best UID for the matching competition is returned."""
         metadata_store = FakeModelMetadataStore()
         metagraph = self._create_metagraph()
-        
+
         # The top miners by incentive are: 4, 3, 6, 2, 7
         # Put miners 3 and 2 in the right competition.
-        asyncio.run(metadata_store.store_model_metadata("hotkey_2", ModelId(namespace="hf", name="model2", competition_id=CompetitionId.SN9_MODEL)))
-        asyncio.run(metadata_store.store_model_metadata("hotkey_3", ModelId(namespace="hf", name="model3", competition_id=CompetitionId.SN9_MODEL)))
-        
+        asyncio.run(
+            metadata_store.store_model_metadata(
+                "hotkey_2",
+                ModelId(
+                    namespace="hf",
+                    name="model2",
+                    competition_id=CompetitionId.SN9_MODEL,
+                ),
+            )
+        )
+        asyncio.run(
+            metadata_store.store_model_metadata(
+                "hotkey_3",
+                ModelId(
+                    namespace="hf",
+                    name="model3",
+                    competition_id=CompetitionId.SN9_MODEL,
+                ),
+            )
+        )
+
         # Put model 4 (the top miner) in a different competition
-        asyncio.run(metadata_store.store_model_metadata("hotkey_4", ModelId(namespace="hf", name="model2", competition_id=CompetitionId.COMPETITION_2)))
+        asyncio.run(
+            metadata_store.store_model_metadata(
+                "hotkey_4",
+                ModelId(
+                    namespace="hf",
+                    name="model2",
+                    competition_id=CompetitionId.B7_MULTI_CHOICE,
+                ),
+            )
+        )
 
-        self.assertEqual(3, graph.best_uid(CompetitionId.SN9_MODEL, metagraph=metagraph, metadata_store=metadata_store))
+        self.assertEqual(
+            3,
+            graph.best_uid(
+                CompetitionId.SN9_MODEL,
+                metagraph=metagraph,
+                metadata_store=metadata_store,
+            ),
+        )
 
-    
     def test_best_uid_no_matching_miners(self):
         """Verifies that None is returned if no miner matches the requested competition."""
         metadata_store = FakeModelMetadataStore()
         metagraph = self._create_metagraph()
-        
+
         # The top miners by incentive are: 4, 3, 6, 2, 7
         # Put miners 3 and 2 in the wrong competition.
-        asyncio.run(metadata_store.store_model_metadata("hotkey_2", ModelId(namespace="hf", name="model2", competition_id=CompetitionId.COMPETITION_2)))
-        asyncio.run(metadata_store.store_model_metadata("hotkey_3", ModelId(namespace="hf", name="model3", competition_id=CompetitionId.COMPETITION_2)))
-        
+        asyncio.run(
+            metadata_store.store_model_metadata(
+                "hotkey_2",
+                ModelId(
+                    namespace="hf",
+                    name="model2",
+                    competition_id=CompetitionId.B7_MULTI_CHOICE,
+                ),
+            )
+        )
+        asyncio.run(
+            metadata_store.store_model_metadata(
+                "hotkey_3",
+                ModelId(
+                    namespace="hf",
+                    name="model3",
+                    competition_id=CompetitionId.B7_MULTI_CHOICE,
+                ),
+            )
+        )
 
-        self.assertIsNone(graph.best_uid(CompetitionId.SN9_MODEL, metagraph=metagraph, metadata_store=metadata_store))
-    
-
-
+        self.assertIsNone(
+            graph.best_uid(
+                CompetitionId.SN9_MODEL,
+                metagraph=metagraph,
+                metadata_store=metadata_store,
+            )
+        )

--- a/tests/finetune/test_mining.py
+++ b/tests/finetune/test_mining.py
@@ -160,7 +160,7 @@ class TestMining(unittest.TestCase):
             ModelId(
                 namespace="hf",
                 name="model2",
-                competition_id=CompetitionId.COMPETITION_2,
+                competition_id=CompetitionId.B7_MULTI_CHOICE,
             ),
         )
 


### PR DESCRIPTION
Adds a new B7_MULTI_CHOICE competition.
- Weights are annealed slowly from a 100/0 split to a 50/50 split at a rate of 5% per 3600 blocks.
- Multiple choice question data is loaded from the PromptingSubnetLoader which pulls from SN1 wandb logs.
- Evaluation asks the models the multiple choice questions and takes the first possible answer returned.

Across all competitions we only keep the 2 top models from eval to eval to speed up the evaluation loop.
Across all competitions we will start using an epsilon with a linear decay instead of a fixed epsilon value.