### PR TITLE
Address win rate bug for competition 2

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -335,8 +335,6 @@ alpha = 0.5
 # validator scoring exponential temperature
 # 0.01 gives ~96% to best model with only ~3 receiving any weights.
 temperature = 0.01
-# validator score boosting for earlier models.
-timestamp_epsilon = 0.005
 # time required between updates to the chain.
 chain_update_cadence = dt.timedelta(minutes=20)
 # Number of blocks required between retrying evaluation of a model.
@@ -344,6 +342,6 @@ model_retry_cadence = 300  # Roughly 1 hour
 # How frequently to check the models given weights by other large validators.
 scan_top_model_cadence = dt.timedelta(minutes=30)
 # validator eval batch min to keep for next loop.
-sample_min = 2
+sample_min = 4
 # We allow the sample_min per competition + 10 additional models to be held at any one time.
 updated_models_limit = sample_min * len(MODEL_CONSTRAINTS_BY_COMPETITION_ID) + 10

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -61,7 +61,7 @@ def validator_config():
     parser.add_argument(
         "--latest_prompting_samples",
         type=int,
-        default=200,
+        default=400,
         help="Number of most recent Prompting samples to eval against",
     )
     parser.add_argument(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -983,7 +983,6 @@ class Validator:
         wins, win_rate = ft.validation.compute_wins(
             uids,
             deviations_per_uid,
-            batches,
             uid_to_block,
             competition.constraints.epsilon_func,
             block,


### PR DESCRIPTION
For multiple-choice competitions, applies the epsilon to the models total deviation rather than per-answer deviation. The latter meant a model would "beat" all later models on questions where they were both incorrect.

Additionally, increased the number of models to eval and increased the sample size to 400. In practice, we only get about 225 samples.