### PR TITLE
Release 2.1.1

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -26,7 +26,7 @@ from competitions.data import CompetitionId
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))
@@ -147,7 +147,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
             norm_eps_soft_percent_threshold=0.15,
             norm_eps_hard=1000,
         ),
-        epsilon_func=LinearDecay(0.005, 0.001, 7200 * 7),  # Decay over ~7 days.
+        epsilon_func=LinearDecay(0.05, 0.01, 7200 * 5),  # Decay over ~5 days.
         max_bytes=15 * 1024 * 1024 * 1024,
     ),
 }

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -26,7 +26,7 @@ from competitions.data import CompetitionId
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))
@@ -290,29 +290,9 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
         3819200,
         [
             Competition(
-                CompetitionId.SN9_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
-                0.55,
-            ),
-            Competition(
                 CompetitionId.B7_MULTI_CHOICE,
                 MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
-                0.45,
-            ),
-        ],
-    ),
-    (
-        3822800,
-        [
-            Competition(
-                CompetitionId.SN9_MODEL,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.SN9_MODEL],
-                0.50,
-            ),
-            Competition(
-                CompetitionId.B7_MULTI_CHOICE,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
-                0.50,
+                1.0,
             ),
         ],
     ),

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -26,7 +26,7 @@ from competitions.data import CompetitionId
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/finetune/datasets/subnet/history_scan.py
+++ b/finetune/datasets/subnet/history_scan.py
@@ -1,0 +1,84 @@
+import json
+
+import requests
+from wandb_gql import gql
+from wandb_gql.client import RetryError
+
+from wandb import util
+from wandb.apis.normalize import normalize_exceptions
+from wandb.sdk.lib import retry
+
+
+# The following is a copy of the HistoryScan class from wandb/apis/public/history.py
+# but with one very important change: the number of retries is set to 3 rather than infinity.
+class SampledHistoryScan:
+    QUERY = gql(
+        """
+        query SampledHistoryPage($entity: String!, $project: String!, $run: String!, $spec: JSONString!) {
+            project(name: $project, entityName: $entity) {
+                run(name: $run) {
+                    sampledHistory(specs: [$spec])
+                }
+            }
+        }
+        """
+    )
+
+    def __init__(self, client, run, keys, min_step, max_step, page_size=1000):
+        self.client = client
+        self.run = run
+        self.keys = keys
+        self.page_size = page_size
+        self.min_step = min_step
+        self.max_step = max_step
+        self.page_offset = min_step  # minStep for next page
+        self.scan_offset = 0  # index within current page of rows
+        self.rows = []  # current page of rows
+
+    def __iter__(self):
+        self.page_offset = self.min_step
+        self.scan_offset = 0
+        self.rows = []
+        return self
+
+    def __next__(self):
+        while True:
+            if self.scan_offset < len(self.rows):
+                row = self.rows[self.scan_offset]
+                self.scan_offset += 1
+                return row
+            if self.page_offset >= self.max_step:
+                raise StopIteration()
+            self._load_next()
+
+    next = __next__
+
+    @normalize_exceptions
+    @retry.retriable(
+        check_retry_fn=util.no_retry_auth,
+        num_retries=3,
+        retryable_exceptions=(RetryError, requests.RequestException),
+    )
+    def _load_next(self):
+        max_step = self.page_offset + self.page_size
+        if max_step > self.max_step:
+            max_step = self.max_step
+        variables = {
+            "entity": self.run.entity,
+            "project": self.run.project,
+            "run": self.run.id,
+            "spec": json.dumps(
+                {
+                    "keys": self.keys,
+                    "minStep": int(self.page_offset),
+                    "maxStep": int(max_step),
+                    "samples": int(self.page_size),
+                }
+            ),
+        }
+
+        res = self.client.execute(self.QUERY, variable_values=variables)
+        res = res["project"]["run"]["sampledHistory"]
+        self.rows = res[0]
+        self.page_offset += self.page_size
+        self.scan_offset = 0

--- a/finetune/datasets/subnet/prompting_subset_loader.py
+++ b/finetune/datasets/subnet/prompting_subset_loader.py
@@ -110,6 +110,8 @@ class PromptingSubsetLoader:
         # Get the runs, oldest first.
         runs = api.runs(prompting_project, filters, order="+created_at")
 
+        bt.logging.debug(f"Found {len(runs)} runs")
+
         if random_seed is not None:
             random.seed(random_seed)
 
@@ -213,6 +215,9 @@ class PromptingSubsetLoader:
                                             self.buffer.append((challenge, reference))
                                             self.selected_samples.add(run_step)
                                             if len(self.buffer) == max_samples:
+                                                bt.logging.debug(
+                                                    f"Collected {max_samples} samples"
+                                                )
                                                 return
 
                                 except KeyError:

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -61,7 +61,7 @@ def validator_config():
     parser.add_argument(
         "--latest_prompting_samples",
         type=int,
-        default=400,
+        default=300,
         help="Number of most recent Prompting samples to eval against",
     )
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ rich
 safetensors
 torch==2.3.1
 transformers==4.44.1
-wandb==0.17.1
+wandb==0.18.0
 taoverse==1.0.5


### PR DESCRIPTION
Hotfix release to address the wandb issue that causes the main thread to hang indefinitely.

There are currently 7 running runs in the prompting wandb prompting. One of those runs (hhodrv2s) is poisoned and all attempts to perform a history scan on it result in a 502 from wandb. Furthermore, the wandb client will INFINITELY RETRY, which is ridiculous.

This change addresses the issue in 2 ways:

1. We reimplement the wandb history client so we can add a sane amount of retries (3). We combine this with a reduction in collected samples to 300, to make it more likely we'll fulfill the 300 samples from 6 runs, should one be poisoned in future.
2. We also use a sampled history scan, which additionally filters (server-side) the steps returned to only those that contain the requested keys. The returned steps also only contain the requested metrics. As a result, it now takes a few seconds to load 300 samples rather than the ~1-2 minutes before!