### PR TITLE
Update to latest taoverse with fixed grace period code.

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -26,7 +26,7 @@ from competitions.data import CompetitionId
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -656,7 +656,7 @@ class Validator:
 
                 self.local_store.delete_unreferenced_models(
                     valid_models_by_hotkey=evaluated_hotkeys_to_model_id,
-                    grace_period_seconds=300,
+                    grace_period_seconds=600,
                 )
             except Exception as e:
                 bt.logging.error(f"Error in clean loop: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ safetensors
 torch==2.3.1
 transformers==4.44.1
 wandb==0.18.0
-taoverse==1.0.5
+taoverse==1.0.6


### PR DESCRIPTION
This updates to the latest taoverse version which correctly gets the newest instead of the oldest filetime in a directory.

Additionally we bump the grace period to 10 minutes. From testing of downloading the current top 14B model the latest filetime in the directory did update quite frequently, but this should provide additional buffer for those with slower connections.

Checking every 10 seconds during the download we found
```
2024-10-09 23:47:21.027041
2024-10-09 23:47:46.778914
2024-10-09 23:47:46.778914
2024-10-09 23:48:12.698787
2024-10-09 23:48:12.698787
2024-10-09 23:48:12.698787
2024-10-09 23:48:39.022657
2024-10-09 23:48:39.022657
2024-10-09 23:48:59.998554
2024-10-09 23:48:59.998554
2024-10-09 23:48:59.998554
2024-10-09 23:48:59.998554
```