### PR TITLE
Improve vtrust

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -139,5 +139,5 @@ model_retry_cadence = 300  # Roughly 1 hour
 scan_top_model_cadence = dt.timedelta(minutes=30)
 # validator eval batch min to keep for next loop.
 sample_min = 4
-# We allow the sample_min per competition + 10 additional models to be held at any one time.
+# We allow the sample_min per competition + 16 additional models to be held at any one time.
 updated_models_limit = sample_min * len(MODEL_CONSTRAINTS_BY_COMPETITION_ID) + 16

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -26,7 +26,7 @@ from competitions.data import CompetitionId
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))
@@ -38,6 +38,16 @@ __spec_version__ = (
 # to start from a fresh state.
 VALIDATOR_STATE_VERSION = 3
 
+# Block the subnet was registered.
+GENESIS_BLOCK = 3138611
+# Define the number of blocks per vali "sync". This cadence is used to align validator behavior for better vtrust.
+SYNC_BLOCK_CADENCE = 90
+# Rough estimate of the number of seconds per block.
+SECONDS_PER_BLOCK = 12
+# Any miners with a combined competition weight below this threshold will instead receive 0 weight.
+# This is to help vtrust by more quickly deprecating previous top models that are being phased out.
+# At 1 eval per 90 blocks, this should mean a model is phased out in ~1.5 epochs.
+MIN_WEIGHT_THRESHOLD = 0.005
 # The validator WANDB project.
 WANDB_PROJECT = "finetuning"
 WANDB_ENTITY = "rusticluftig"
@@ -52,8 +62,6 @@ PROMPTING_WANDB_PROJECT = "macrocosmos/prompting-validators"
 PROMPTING_MAX_AGE = dt.timedelta(hours=4)
 # Minimum number of samples allowed to consider MMLU as an eval task.
 MIN_ALLOWED_SAMPLES = 50
-# Percentage of promping miners who must have gotten the question correct to include in the eval set.
-PROMPTING_MIN_CORRECT_MINERS = 0
 # Minimum stake to consider a validator when checking for miners with weights.
 WEIGHT_SYNC_VALI_MIN_STAKE = 100_000
 # Minimum percent of weight on a vali for a miner to be considered a top miner.
@@ -91,9 +99,6 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         max_bytes=15 * 1024 * 1024 * 1024,
     ),
 }
-
-# Block at which word sorting is including in the competition eval.
-WORD_SORTING_BLOCK = 4139465
 
 # Schedule of competitions by block.
 COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
@@ -135,4 +140,4 @@ scan_top_model_cadence = dt.timedelta(minutes=30)
 # validator eval batch min to keep for next loop.
 sample_min = 4
 # We allow the sample_min per competition + 10 additional models to be held at any one time.
-updated_models_limit = sample_min * len(MODEL_CONSTRAINTS_BY_COMPETITION_ID) + 10
+updated_models_limit = sample_min * len(MODEL_CONSTRAINTS_BY_COMPETITION_ID) + 16

--- a/finetune/__init__.py
+++ b/finetune/__init__.py
@@ -19,3 +19,4 @@ from . import graph
 from . import mining
 from . import validation
 from . import model
+from . import utils

--- a/finetune/utils.py
+++ b/finetune/utils.py
@@ -1,0 +1,45 @@
+import math
+import bittensor as bt
+import datetime as dt
+
+
+def get_block_timestamp(subtensor: bt.subtensor, block_number: int) -> dt.datetime:
+    """Returns a timezone-aware datetime object for the timestamp of the block."""
+    block_data = subtensor.substrate.get_block(block_number=block_number)
+    timestamp = block_data["extrinsics"][0]["call"]["call_args"][0]["value"]
+    timestamp_seconds = timestamp.value / 1000
+    return dt.datetime.fromtimestamp(timestamp_seconds).astimezone(dt.timezone.utc)
+
+
+def get_hash_of_block(subtensor: bt.subtensor, block_number: int) -> int:
+    """Returns the hash of the block at the given block number."""
+    return hash(subtensor.get_block_hash(block_number))
+
+
+def get_sync_block(block: int, sync_cadence: int, genesis: int = 0) -> int:
+    """Returns the most recent sync block that is on or before `block`.
+
+    Args:
+        block (int): The block number.
+        sync_cadence (int): The cadence of blocks to sync on.
+        genesis (int, optional): The genesis block number. Defaults to 0. This can be used to synchronize on a subnet's epoch.
+    """
+    sync_block = (block - genesis) // sync_cadence * sync_cadence + genesis
+    return sync_block
+
+
+def get_next_sync_block(block: int, sync_cadence: int, genesis: int = 0) -> int:
+    """Returns the next sync block that is after "block"
+
+    Args:
+        block (int): The block number.
+        sync_cadence (int): The cadence of blocks to sync on.
+        genesis (int, optional): The genesis block number. Defaults to 0. This can be used to synchronize on a subnet's epoch.
+    """
+    sync_block = (
+        int(math.ceil((block - genesis) / sync_cadence)) * sync_cadence + genesis
+    )
+    # Make sure the sync_block is strictly after the block.
+    if sync_block == block:
+        sync_block += sync_cadence
+    return sync_block

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -41,15 +41,9 @@ def validator_config():
         help="Number of blocks to wait before setting weights.",
     )
     parser.add_argument(
-        "--latest_prompting_steps",
-        type=int,
-        default=500,  # Sample more steps since prompting runs this less frequently.
-        help="Number of most recent Prompting steps to sample data from",
-    )
-    parser.add_argument(
         "--latest_prompting_samples",
         type=int,
-        default=400,
+        default=700,
         help="Number of most recent Prompting samples to eval against",
     )
     parser.add_argument(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -128,7 +128,6 @@ class Validator:
         # === Bittensor objects ====
         self.wallet = bt.wallet(config=self.config)
         self.subtensor = bt.subtensor(config=self.config)
-        # self.archive_subtensor = bt.subtensor("archive")
         # If running on testnet, default to using finney for the dataset subtensor.
         if self.config.using_test_subtensor:
             self.dataset_subtensor = bt.subtensor()
@@ -513,7 +512,7 @@ class Validator:
             except MinerMisconfiguredError as e:
                 bt.logging.trace(e)
             except Exception as e:
-                bt.logging.trace(
+                bt.logging.debug(
                     f"Error in update loop: {e} \n {traceback.format_exc()}"
                 )
 
@@ -765,7 +764,7 @@ class Validator:
                 [self.prompting_metagraph.hotkeys[uid] for uid in vali_uids]
             )
 
-        # We want to ensure we only include data that is strictly older than eval_delay_blocks ago and younger than the current
+        # We want to ensure we only include data that is strictly newer than eval_delay_blocks ago and older than the current
         # sync block. This ensures that all validators running an eval in this current sync_block will load ~ the same data.
         oldest_sync_block = ft.utils.get_next_sync_block(
             current_block - eval_delay_blocks,

--- a/scripts/model_validation.py
+++ b/scripts/model_validation.py
@@ -3,6 +3,7 @@
 It can be used to estimate the performance of a model before submitting it."""
 
 import argparse
+import datetime as dt
 import math
 import random
 import sys
@@ -61,15 +62,9 @@ def main():
         help="Random seed to use while loading data. If 0 then randomize.",
     )
     parser.add_argument(
-        "--latest_prompting_steps",
-        type=int,
-        default=500,
-        help="Number of most recent prompting steps to sample data from",
-    )
-    parser.add_argument(
         "--latest_prompting_samples",
         type=int,
-        default=100,
+        default=400,
         help="Number of most recent prompting samples to eval against",
     )
     parser.add_argument(
@@ -147,12 +142,9 @@ def main():
         print("Getting latest sample data from prompting.")
         with pull_data_perf.sample():
             sample_data = PromptingSubsetLoader(
-                use_latest_data=True,
                 random_seed=seed,
                 max_samples=args.latest_prompting_samples,
-                steps=args.latest_prompting_steps,
-                page_size=args.latest_prompting_steps,
-                min_percent_correct=constants.PROMPTING_MIN_CORRECT_MINERS,
+                oldest_sample_timestamp=dt.datetime.now() - dt.timedelta(hours=4),
             )
     else:
         print(

--- a/tests/finetune/test_utils.py
+++ b/tests/finetune/test_utils.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import MagicMock
+
+import bittensor as bt
+import substrateinterface as si
+
+from finetune.utils import (
+    get_hash_of_block,
+    get_hash_of_sync_block,
+    get_next_sync_block,
+    get_sync_block,
+)
+
+
+class TestUtils(unittest.TestCase):
+
+    def setUp(self):
+        self.subtensor = MagicMock(spec=bt.subtensor)
+        self.subtensor.substrate = MagicMock(spec=si.SubstrateInterface)
+
+    def test_get_hash_of_sync_block(self):
+        self.subtensor.get_current_block.return_value = 12345
+        self.subtensor.get_block_hash.return_value = "some_hash"
+        sync_cadence = 100
+        expected_sync_block = 12300
+
+        result = get_hash_of_sync_block(self.subtensor, sync_cadence)
+
+        self.assertEqual(result, hash("some_hash"))
+        self.subtensor.get_block_hash.assert_called_once_with(expected_sync_block)
+
+    def test_get_hash_of_block(self):
+        block_number = 12345
+        self.subtensor.get_block_hash.return_value = "some_hash"
+
+        result = get_hash_of_block(self.subtensor, block_number)
+
+        self.assertEqual(result, hash("some_hash"))
+        self.subtensor.get_block_hash.assert_called_once_with(block_number)
+
+    def test_get_sync_block(self):
+        sync_cadence = 100
+        genesis = 1_111_111
+        for block in range(1_234_511, 1_234_611):
+            self.assertEqual(get_sync_block(block, sync_cadence, genesis), 1_234_511)
+
+        # Now check the next block is the start of a new sync block.
+        self.assertEqual(get_sync_block(1_234_611, sync_cadence, genesis), 1_234_611)
+
+    def test_get_next_sync_block(self):
+        sync_cadence = 100
+        genesis = 1_111_111
+        for block in range(1_234_511, 1_234_611):
+            self.assertEqual(
+                get_next_sync_block(block, sync_cadence, genesis), 1_234_611
+            )
+
+        # Now check the next block is the start of a new sync block.
+        self.assertEqual(
+            get_next_sync_block(1_234_611, sync_cadence, genesis), 1_234_711
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
V-trust improvements:
1. Improving the dataset loader to get more samples (No longer use "MultiChoiceRewardModel_rewards" which was causing a lot of samples to be dropped by wandb. I don't know why)
2. Aligning validator evaluations to "sync blocks" to reduce the variance in evaluations performed across validators
3. Switch to a WTA weight rather than softmax
4. Set weight to 0 for models with very little weight

Other improvements:
1. Correctly handle set_weight errors
2. Since we're now rate limiting eval loops, increases the number of models per loop to 20.