### PR TITLE
Adjust alpha and min weight threshold.

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -48,10 +48,15 @@ GENESIS_BLOCK = 3138611
 SYNC_BLOCK_CADENCE = 90
 # Rough estimate of the number of seconds per block.
 SECONDS_PER_BLOCK = 12
+# Validator weight moving average term.
+# At 0.05 a model will go from 0 -> 0.143 in 3 cycles and from 0 -> 0.901 in 45 cycles.
+ALPHA = 0.05
 # Any miners with a combined competition weight below this threshold will instead receive 0 weight.
-# This is to help vtrust by more quickly deprecating previous top models that are being phased out.
-# At 1 eval per 90 blocks, this should mean a model is phased out in ~1.5 epochs.
-MIN_WEIGHT_THRESHOLD = 0.005
+# This is intended to help vtrust in conjunction with a low alpha by handling the tail ends.
+# At 1 eval per 90 blocks, newly winning models will start recieving weight after ~270 blocks.
+# Previously winning models will phase out after ~4050 blocks, at which point only the new winner will have weight.
+MIN_WEIGHT_THRESHOLD = 0.1
+
 # The validator WANDB project.
 WANDB_PROJECT = "finetuning"
 WANDB_ENTITY = "rusticluftig"
@@ -190,11 +195,6 @@ for block_and_competitions in COMPETITION_SCHEDULE_BY_BLOCK:
 
 weights_version_key = __spec_version__
 
-# validator weight moving average term
-alpha = 0.5
-# validator scoring exponential temperature
-# 0.01 gives ~96% to best model with only ~3 receiving any weights.
-temperature = 0.01
 # time required between updates to the chain.
 chain_update_cadence = dt.timedelta(minutes=20)
 # Number of blocks required between retrying evaluation of a model.

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -217,7 +217,7 @@ class Validator:
 
         # Setup a competition tracker to track weights across different competitions.
         self.competition_tracker = CompetitionTracker(
-            num_neurons=len(self.metagraph.uids), alpha=constants.alpha
+            num_neurons=len(self.metagraph.uids), alpha=constants.ALPHA
         )
         # Keep track of the most recent sync block used when the competition was last evaluated.
         self.last_run_by_competition = defaultdict(int)


### PR DESCRIPTION
Adjust alpha to 0.05 and min weight threshold to 0.1.

In a situation with only one clearly winning model that means:

1) It takes 3 cycles of winning in a row to go from 0 weight to 0.143 weight and cross the 0.1 threshold.
2) It takes 45 cycles of winning in a row to go from 0 weight to 0.901 weight and ensure no other models have >= 0.1 weight.
3) As a corollary to 2) that means if a model has 1 weight, it takes 45 cycles to drop below 0.1 weight.

Note: Temperature is no longer used in this subnet and the constant for it was also removed in this change.