### PR TITLE
Add retries to fetching the block

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -753,11 +753,16 @@ class Validator:
 
     def _get_current_block(self) -> int:
         """Returns the current block."""
-        try:
+
+        @retry(tries=5, delay=1, backoff=2)
+        def _get_block_with_retry():
             return self.subtensor.block
+
+        try:
+            return _get_block_with_retry()
         except:
             bt.logging.debug(
-                "Failed to get the latest block from the chain. Using the block from the cached metagraph."
+                f"Failed to get the latest block from the chain. Using the block from the cached metagraph."
             )
             # Network call failed. Fallback to using the block from the metagraph,
             # even though it'll be a little stale.

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -762,7 +762,7 @@ class Validator:
             return _get_block_with_retry()
         except:
             bt.logging.debug(
-                f"Failed to get the latest block from the chain. Using the block from the cached metagraph."
+                "Failed to get the latest block from the chain. Using the block from the cached metagraph."
             )
             # Network call failed. Fallback to using the block from the metagraph,
             # even though it'll be a little stale.


### PR DESCRIPTION
This call seems to fail more frequently on 8.4.3. After adding retries, I no longer saw this fail (all 5 attempts)