### PR TITLE
Fix seed used across valis

### DIFF
--- a/finetune/utils.py
+++ b/finetune/utils.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import hashlib
 import math
 
 import bittensor as bt
@@ -14,7 +15,11 @@ def get_block_timestamp(subtensor: bt.subtensor, block_number: int) -> dt.dateti
 
 def get_hash_of_block(subtensor: bt.subtensor, block_number: int) -> int:
     """Returns the hash of the block at the given block number."""
-    return hash(subtensor.get_block_hash(block_number))
+    block_hash = subtensor.get_block_hash(block_number)
+    # Convert to an int.
+    # Use hashlib instead of hash() since the latter is not deterministic across sessions.
+    hasher = hashlib.sha256(block_hash.encode("utf-8"))
+    return int(hasher.hexdigest(), 16)
 
 
 def get_sync_block(block: int, sync_cadence: int, genesis: int = 0) -> int:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -984,7 +984,9 @@ class Validator:
             await self.run_step()
             return
 
-        logging.info("Starting evaluation for competition: " + str(competition.id))
+        logging.info(
+            f"Starting evaluation for competition {str(competition.id)} using sync block {sync_block}."
+        )
 
         # If the competition's eval tasks have changed, make sure all models are re-evaluated.
         # Commenting out for now. Churn from IfEval changes should not actual require a reset.
@@ -1247,6 +1249,7 @@ class Validator:
             uid_to_state,
             self._get_uids_to_competition_ids(),
             seed,
+            sync_block,
             wins,
             win_rate,
             tracker_competition_weights,
@@ -1322,6 +1325,7 @@ class Validator:
         uid_to_state: typing.Dict[int, PerUIDEvalState],
         uid_to_competition_id: typing.Dict[int, typing.Optional[int]],
         seed: int,
+        sync_block: int,
         wins: typing.Dict[int, int],
         win_rate: typing.Dict[int, float],
         competition_weights: torch.Tensor,
@@ -1336,6 +1340,7 @@ class Validator:
             "timestamp": time.time(),
             "competition_id": competition.id,
             "seed": seed,
+            "sync_block": sync_block or "None",
             "uids": uids,
             "uid_data": {},
         }

--- a/tests/finetune/test_utils.py
+++ b/tests/finetune/test_utils.py
@@ -18,12 +18,17 @@ class TestUtils(unittest.TestCase):
         self.subtensor.substrate = MagicMock(spec=si.SubstrateInterface)
 
     def test_get_hash_of_block(self):
-        block_number = 12345
-        self.subtensor.get_block_hash.return_value = "some_hash"
+        block_number = 4_632_000
+        self.subtensor.get_block_hash.return_value = (
+            "0xf0c1d88fffb58f2de2798abb2236460f426b02a9c84cad7463188eff75140bd2"
+        )
 
         result = get_hash_of_block(self.subtensor, block_number)
 
-        self.assertEqual(result, hash("some_hash"))
+        self.assertEqual(
+            result,
+            592572197532882810092427479703237300164718763613437077128565525142151814165,
+        )
         self.subtensor.get_block_hash.assert_called_once_with(block_number)
 
     def test_get_sync_block(self):


### PR DESCRIPTION
To my surprise, hash() is not deterministic across sessions...

Switch over to hashlib which is deterministic.