### PR TITLE
Release 2.8.0

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -33,7 +33,7 @@ from finetune.eval.if_eval.version import IfEvalVersion
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.7.2"
+__version__ = "2.8.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -140,137 +140,12 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
     ),
 }
 
-INSTRUCT_8B_BLOCK = 4_451_695
-IF_EVAL_V2_BLOCK = 4_523_592
+INSTRUCT_8B_TO_25_WEIGHT_BLOCK = 4_552_883
 
 # Schedule of competitions by block.
 COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
     (
         0,
-        [
-            Competition(
-                CompetitionId.B7_MULTI_CHOICE,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
-                1.0,
-                eval_tasks=[
-                    EvalTask(
-                        name="SYNTHETIC_MMLU",
-                        method_id=EvalMethodId.MULTIPLE_CHOICE,
-                        dataset_id=DatasetId.SYNTHETIC_MMLU,
-                        normalization_id=NormalizationId.NONE,
-                        weight=0.85,
-                    ),
-                    EvalTask(
-                        name="WORD_SORTING",
-                        method_id=EvalMethodId.REFERENCE_LOSS,
-                        dataset_id=DatasetId.WORD_SORTING,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 40.0},
-                        weight=0.05,
-                    ),
-                    EvalTask(
-                        name="FINEWEB",
-                        method_id=EvalMethodId.TEXT_LOSS,
-                        dataset_id=DatasetId.FINEWEB,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 20.0},
-                        weight=0.05,
-                    ),
-                    EvalTask(
-                        name="IF_EVAL_V1",
-                        method_id=EvalMethodId.IF_EVAL,
-                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
-                        normalization_id=NormalizationId.NONE,
-                        dataset_kwargs={"if_eval_version": IfEvalVersion.V1},
-                        weight=0.05,
-                    ),
-                ],
-            ),
-        ],
-    ),
-    (
-        INSTRUCT_8B_BLOCK,
-        [
-            Competition(
-                CompetitionId.B7_MULTI_CHOICE,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
-                0.9,
-                eval_tasks=[
-                    EvalTask(
-                        name="SYNTHETIC_MMLU",
-                        method_id=EvalMethodId.MULTIPLE_CHOICE,
-                        dataset_id=DatasetId.SYNTHETIC_MMLU,
-                        normalization_id=NormalizationId.NONE,
-                        weight=0.8,
-                    ),
-                    EvalTask(
-                        name="WORD_SORTING",
-                        method_id=EvalMethodId.REFERENCE_LOSS,
-                        dataset_id=DatasetId.WORD_SORTING,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 40.0},
-                        weight=0.05,
-                    ),
-                    EvalTask(
-                        name="FINEWEB",
-                        method_id=EvalMethodId.TEXT_LOSS,
-                        dataset_id=DatasetId.FINEWEB,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 20.0},
-                        weight=0.1,
-                    ),
-                    EvalTask(
-                        name="IF_EVAL_V1",
-                        method_id=EvalMethodId.IF_EVAL,
-                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
-                        normalization_id=NormalizationId.NONE,
-                        dataset_kwargs={"if_eval_version": IfEvalVersion.V1},
-                        weight=0.05,
-                    ),
-                ],
-            ),
-            Competition(
-                CompetitionId.INSTRUCT_8B,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.INSTRUCT_8B],
-                0.1,
-                eval_tasks=[
-                    EvalTask(
-                        name="SYNTHETIC_MMLU",
-                        method_id=EvalMethodId.MULTIPLE_CHOICE,
-                        dataset_id=DatasetId.SYNTHETIC_MMLU,
-                        normalization_id=NormalizationId.NONE,
-                        weight=0.8,
-                    ),
-                    EvalTask(
-                        name="WORD_SORTING",
-                        method_id=EvalMethodId.REFERENCE_LOSS,
-                        dataset_id=DatasetId.WORD_SORTING,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 40.0},
-                        weight=0.05,
-                    ),
-                    EvalTask(
-                        name="FINEWEB",
-                        method_id=EvalMethodId.TEXT_LOSS,
-                        dataset_id=DatasetId.FINEWEB,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 20.0},
-                        weight=0.1,
-                    ),
-                    EvalTask(
-                        name="IF_EVAL_V1",
-                        method_id=EvalMethodId.IF_EVAL,
-                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
-                        normalization_id=NormalizationId.NONE,
-                        dataset_kwargs={"if_eval_version": IfEvalVersion.V1},
-                        weight=0.05,
-                    ),
-                ],
-            ),
-        ],
-    ),
-    (
-        IF_EVAL_V2_BLOCK,
         [
             Competition(
                 CompetitionId.B7_MULTI_CHOICE,
@@ -314,6 +189,87 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                 CompetitionId.INSTRUCT_8B,
                 MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.INSTRUCT_8B],
                 0.1,
+                eval_tasks=[
+                    EvalTask(
+                        name="SYNTHETIC_MMLU",
+                        method_id=EvalMethodId.MULTIPLE_CHOICE,
+                        dataset_id=DatasetId.SYNTHETIC_MMLU,
+                        normalization_id=NormalizationId.NONE,
+                        weight=0.75,
+                    ),
+                    EvalTask(
+                        name="WORD_SORTING",
+                        method_id=EvalMethodId.REFERENCE_LOSS,
+                        dataset_id=DatasetId.WORD_SORTING,
+                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
+                        normalization_kwargs={"ceiling": 40.0},
+                        weight=0.05,
+                    ),
+                    EvalTask(
+                        name="FINEWEB",
+                        method_id=EvalMethodId.TEXT_LOSS,
+                        dataset_id=DatasetId.FINEWEB,
+                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
+                        normalization_kwargs={"ceiling": 20.0},
+                        weight=0.1,
+                    ),
+                    EvalTask(
+                        name="IF_EVAL_V2",
+                        method_id=EvalMethodId.IF_EVAL,
+                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
+                        normalization_id=NormalizationId.NONE,
+                        dataset_kwargs={"if_eval_version": IfEvalVersion.V2},
+                        weight=0.1,
+                    ),
+                ],
+            ),
+        ],
+    ),
+    (
+        INSTRUCT_8B_TO_25_WEIGHT_BLOCK,
+        [
+            Competition(
+                CompetitionId.B7_MULTI_CHOICE,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
+                0.75,
+                eval_tasks=[
+                    EvalTask(
+                        name="SYNTHETIC_MMLU",
+                        method_id=EvalMethodId.MULTIPLE_CHOICE,
+                        dataset_id=DatasetId.SYNTHETIC_MMLU,
+                        normalization_id=NormalizationId.NONE,
+                        weight=0.75,
+                    ),
+                    EvalTask(
+                        name="WORD_SORTING",
+                        method_id=EvalMethodId.REFERENCE_LOSS,
+                        dataset_id=DatasetId.WORD_SORTING,
+                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
+                        normalization_kwargs={"ceiling": 40.0},
+                        weight=0.05,
+                    ),
+                    EvalTask(
+                        name="FINEWEB",
+                        method_id=EvalMethodId.TEXT_LOSS,
+                        dataset_id=DatasetId.FINEWEB,
+                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
+                        normalization_kwargs={"ceiling": 20.0},
+                        weight=0.1,
+                    ),
+                    EvalTask(
+                        name="IF_EVAL_V2",
+                        method_id=EvalMethodId.IF_EVAL,
+                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
+                        normalization_id=NormalizationId.NONE,
+                        dataset_kwargs={"if_eval_version": IfEvalVersion.V2},
+                        weight=0.1,
+                    ),
+                ],
+            ),
+            Competition(
+                CompetitionId.INSTRUCT_8B,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.INSTRUCT_8B],
+                0.25,
                 eval_tasks=[
                     EvalTask(
                         name="SYNTHETIC_MMLU",

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -140,93 +140,12 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
     ),
 }
 
-INSTRUCT_8B_TO_25_WEIGHT_BLOCK = 4_552_883
+SUNSET_B7_BLOCK = 4_675_163
 
 # Schedule of competitions by block.
 COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
     (
         0,
-        [
-            Competition(
-                CompetitionId.B7_MULTI_CHOICE,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.B7_MULTI_CHOICE],
-                0.9,
-                eval_tasks=[
-                    EvalTask(
-                        name="SYNTHETIC_MMLU",
-                        method_id=EvalMethodId.MULTIPLE_CHOICE,
-                        dataset_id=DatasetId.SYNTHETIC_MMLU,
-                        normalization_id=NormalizationId.NONE,
-                        weight=0.75,
-                    ),
-                    EvalTask(
-                        name="WORD_SORTING",
-                        method_id=EvalMethodId.REFERENCE_LOSS,
-                        dataset_id=DatasetId.WORD_SORTING,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 40.0},
-                        weight=0.05,
-                    ),
-                    EvalTask(
-                        name="FINEWEB",
-                        method_id=EvalMethodId.TEXT_LOSS,
-                        dataset_id=DatasetId.FINEWEB,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 20.0},
-                        weight=0.1,
-                    ),
-                    EvalTask(
-                        name="IF_EVAL_V2",
-                        method_id=EvalMethodId.IF_EVAL,
-                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
-                        normalization_id=NormalizationId.NONE,
-                        dataset_kwargs={"if_eval_version": IfEvalVersion.V2},
-                        weight=0.1,
-                    ),
-                ],
-            ),
-            Competition(
-                CompetitionId.INSTRUCT_8B,
-                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.INSTRUCT_8B],
-                0.1,
-                eval_tasks=[
-                    EvalTask(
-                        name="SYNTHETIC_MMLU",
-                        method_id=EvalMethodId.MULTIPLE_CHOICE,
-                        dataset_id=DatasetId.SYNTHETIC_MMLU,
-                        normalization_id=NormalizationId.NONE,
-                        weight=0.75,
-                    ),
-                    EvalTask(
-                        name="WORD_SORTING",
-                        method_id=EvalMethodId.REFERENCE_LOSS,
-                        dataset_id=DatasetId.WORD_SORTING,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 40.0},
-                        weight=0.05,
-                    ),
-                    EvalTask(
-                        name="FINEWEB",
-                        method_id=EvalMethodId.TEXT_LOSS,
-                        dataset_id=DatasetId.FINEWEB,
-                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
-                        normalization_kwargs={"ceiling": 20.0},
-                        weight=0.1,
-                    ),
-                    EvalTask(
-                        name="IF_EVAL_V2",
-                        method_id=EvalMethodId.IF_EVAL,
-                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
-                        normalization_id=NormalizationId.NONE,
-                        dataset_kwargs={"if_eval_version": IfEvalVersion.V2},
-                        weight=0.1,
-                    ),
-                ],
-            ),
-        ],
-    ),
-    (
-        INSTRUCT_8B_TO_25_WEIGHT_BLOCK,
         [
             Competition(
                 CompetitionId.B7_MULTI_CHOICE,
@@ -301,6 +220,49 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                         normalization_id=NormalizationId.NONE,
                         dataset_kwargs={"if_eval_version": IfEvalVersion.V2},
                         weight=0.1,
+                    ),
+                ],
+            ),
+        ],
+    ),
+    (
+        SUNSET_B7_BLOCK,
+        [
+            Competition(
+                CompetitionId.INSTRUCT_8B,
+                MODEL_CONSTRAINTS_BY_COMPETITION_ID[CompetitionId.INSTRUCT_8B],
+                1.0,
+                eval_tasks=[
+                    EvalTask(
+                        name="SYNTHETIC_MMLU",
+                        method_id=EvalMethodId.MULTIPLE_CHOICE,
+                        dataset_id=DatasetId.SYNTHETIC_MMLU,
+                        normalization_id=NormalizationId.NONE,
+                        weight=0.65,
+                    ),
+                    EvalTask(
+                        name="WORD_SORTING",
+                        method_id=EvalMethodId.REFERENCE_LOSS,
+                        dataset_id=DatasetId.WORD_SORTING,
+                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
+                        normalization_kwargs={"ceiling": 40.0},
+                        weight=0.05,
+                    ),
+                    EvalTask(
+                        name="FINEWEB",
+                        method_id=EvalMethodId.TEXT_LOSS,
+                        dataset_id=DatasetId.FINEWEB,
+                        normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
+                        normalization_kwargs={"ceiling": 20.0},
+                        weight=0.1,
+                    ),
+                    EvalTask(
+                        name="IF_EVAL_V2",
+                        method_id=EvalMethodId.IF_EVAL,
+                        dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
+                        normalization_id=NormalizationId.NONE,
+                        dataset_kwargs={"if_eval_version": IfEvalVersion.V2},
+                        weight=0.2,
                     ),
                 ],
             ),

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -33,7 +33,7 @@ from finetune.eval.if_eval.version import IfEvalVersion
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/docs/examples.ipynb
+++ b/docs/examples.ipynb
@@ -13,18 +13,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"In this example, we load and print the Hugging Face URL for the best-model in the B7_MULTI_CHOICE competition.\"\"\"\n",
+    "\"\"\"In this example, we load and print the Hugging Face URL for the best-model in the INSTRUCT_8B competition.\"\"\"\n",
     "\n",
     "import finetune as ft\n",
     "from competitions.data import CompetitionId\n",
     "\n",
     "# Each model competes in a single competition. Find the best top performing miner UID for the \n",
-    "# competition we care about (B7_MULTI_CHOICE, in this example).\n",
-    "top_model_uid = ft.graph.best_uid(competition_id=CompetitionId.B7_MULTI_CHOICE)\n",
+    "# competition we care about (INSTRUCT_8B, in this example).\n",
+    "top_model_uid = ft.graph.best_uid(competition_id=CompetitionId.INSTRUCT_8B)\n",
     "\n",
     "# Get the HuggingFace URL for this model.\n",
     "repo_url = await ft.mining.get_repo(top_model_uid)\n",
-    "print(f\"The best-performing model for B7_MULTI_CHOICE competition is {repo_url}\")"
+    "print(f\"The best-performing model for INSTRUCT_8B competition is {repo_url}\")"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"In this example, we load and print the actual metadata on the chain for the current best-model in the B7_MULTI_CHOICE competition.\"\"\"\n",
+    "\"\"\"In this example, we load and print the actual metadata on the chain for the current best-model in the INSTRUCT_8B competition.\"\"\"\n",
     "\n",
     "# NOTE: Run the first cell to get the top model uid first.\n",
     "import bittensor as bt\n",
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"In this example, we load the top model for the B7_MULTI_CHOICE competition and converse with it.\"\"\"\n",
+    "\"\"\"In this example, we load the top model for the INSTRUCT_8B competition and converse with it.\"\"\"\n",
     "\n",
     "import bittensor as bt\n",
     "import torch\n",
@@ -88,7 +88,7 @@
     "# Download the top model to the specified directory.\n",
     "download_dir = \"./finetune-example\"\n",
     "model = await ft.mining.load_best_model(\n",
-    "    download_dir=download_dir, competition_id=CompetitionId.B7_MULTI_CHOICE\n",
+    "    download_dir=download_dir, competition_id=CompetitionId.INSTRUCT_8B\n",
     ")\n",
     "\n",
     "# Move the model to the appropriate device and set to eval mode.\n",
@@ -98,7 +98,7 @@
     "# Load the competition so we can load the right tokenizer.\n",
     "metagraph = bt.metagraph(constants.SUBNET_UID)\n",
     "competition = competition_utils.get_competition_for_block(\n",
-    "    CompetitionId.B7_MULTI_CHOICE,\n",
+    "    CompetitionId.INSTRUCT_8B,\n",
     "    metagraph.block,\n",
     "    constants.COMPETITION_SCHEDULE_BY_BLOCK,\n",
     ")\n",
@@ -160,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/finetune/utils.py
+++ b/finetune/utils.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import hashlib
 import math
 
 import bittensor as bt
@@ -14,7 +15,11 @@ def get_block_timestamp(subtensor: bt.subtensor, block_number: int) -> dt.dateti
 
 def get_hash_of_block(subtensor: bt.subtensor, block_number: int) -> int:
     """Returns the hash of the block at the given block number."""
-    return hash(subtensor.get_block_hash(block_number))
+    block_hash = subtensor.get_block_hash(block_number)
+    # Convert to an int.
+    # Use hashlib instead of hash() since the latter is not deterministic across sessions.
+    hasher = hashlib.sha256(block_hash.encode("utf-8"))
+    return int(hasher.hexdigest(), 16)
 
 
 def get_sync_block(block: int, sync_cadence: int, genesis: int = 0) -> int:

--- a/neurons/config.py
+++ b/neurons/config.py
@@ -179,7 +179,7 @@ def miner_config():
     parser.add_argument(
         "--competition_id",
         type=CompetitionId,
-        default=CompetitionId.B7_MULTI_CHOICE.value,
+        default=CompetitionId.INSTRUCT_8B.value,
         action=IntEnumAction,
         help="competition to mine for (use --list-competitions to get all competitions)",
     )

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -984,7 +984,9 @@ class Validator:
             await self.run_step()
             return
 
-        logging.info("Starting evaluation for competition: " + str(competition.id))
+        logging.info(
+            f"Starting evaluation for competition {str(competition.id)} using sync block {sync_block}."
+        )
 
         # If the competition's eval tasks have changed, make sure all models are re-evaluated.
         # Commenting out for now. Churn from IfEval changes should not actual require a reset.
@@ -1247,6 +1249,7 @@ class Validator:
             uid_to_state,
             self._get_uids_to_competition_ids(),
             seed,
+            sync_block,
             wins,
             win_rate,
             tracker_competition_weights,
@@ -1322,6 +1325,7 @@ class Validator:
         uid_to_state: typing.Dict[int, PerUIDEvalState],
         uid_to_competition_id: typing.Dict[int, typing.Optional[int]],
         seed: int,
+        sync_block: int,
         wins: typing.Dict[int, int],
         win_rate: typing.Dict[int, float],
         competition_weights: torch.Tensor,
@@ -1336,6 +1340,7 @@ class Validator:
             "timestamp": time.time(),
             "competition_id": competition.id,
             "seed": seed,
+            "sync_block": sync_block or "None",
             "uids": uids,
             "uid_data": {},
         }

--- a/scripts/model_validation.py
+++ b/scripts/model_validation.py
@@ -46,7 +46,7 @@ def main():
     parser.add_argument(
         "--competition_id",
         type=CompetitionId,
-        default=CompetitionId.B7_MULTI_CHOICE.value,
+        default=CompetitionId.INSTRUCT_8B.value,
         action=IntEnumAction,
         help="competition to mine for (use --list-competitions to get all competitions)",
     )

--- a/scripts/upload_model.py
+++ b/scripts/upload_model.py
@@ -58,7 +58,7 @@ def get_config():
     parser.add_argument(
         "--competition_id",
         type=CompetitionId,
-        default=CompetitionId.B7_MULTI_CHOICE.value,
+        default=CompetitionId.INSTRUCT_8B.value,
         action=IntEnumAction,
         help="competition to mine for (use --list-competitions to get all competitions)",
     )

--- a/tests/finetune/test_utils.py
+++ b/tests/finetune/test_utils.py
@@ -18,12 +18,17 @@ class TestUtils(unittest.TestCase):
         self.subtensor.substrate = MagicMock(spec=si.SubstrateInterface)
 
     def test_get_hash_of_block(self):
-        block_number = 12345
-        self.subtensor.get_block_hash.return_value = "some_hash"
+        block_number = 4_632_000
+        self.subtensor.get_block_hash.return_value = (
+            "0xf0c1d88fffb58f2de2798abb2236460f426b02a9c84cad7463188eff75140bd2"
+        )
 
         result = get_hash_of_block(self.subtensor, block_number)
 
-        self.assertEqual(result, hash("some_hash"))
+        self.assertEqual(
+            result,
+            592572197532882810092427479703237300164718763613437077128565525142151814165,
+        )
         self.subtensor.get_block_hash.assert_called_once_with(block_number)
 
     def test_get_sync_block(self):


### PR DESCRIPTION
- Sunset the B7_MULTI_CHOICE at block 4_675_163 and giving full weight to INSTRUCT_8B.
- The IFEval evaluation task weight is increased to 20% at block 4_675_163 and weight on MMLU has decreased to 65%
- Fixed a bug causing the random seeds to differ across validators (it turns out python's hash() function isn't deterministic across sessions/machines...who knew? 🤔 ). This should reduce model evaluation variance and improve vTrust. 