### PR TITLE
Send subtensor requests less aggressively.

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -47,6 +47,7 @@ import time
 import traceback
 import typing
 from collections import defaultdict
+from websockets.exceptions import InvalidStatus
 
 import bittensor as bt
 import nltk
@@ -576,6 +577,11 @@ class Validator:
                         logging.warning(
                             f"Failed to find metadata for uid {next_uid} with hotkey {hotkey}"
                         )
+            except InvalidStatus as e:
+                logging.info(
+                    f"Websocket exception in update loop: {e}. Waiting 3 minutes."
+                )
+                time.sleep(180)
             except MinerMisconfiguredError as e:
                 logging.trace(e)
             except Exception as e:
@@ -763,11 +769,11 @@ class Validator:
                 set_weights_success = False
                 while not set_weights_success:
                     set_weights_success, _ = asyncio.run(self.try_set_weights(ttl=60))
-                    # Wait for 60 seconds before we try to set weights again.
+                    # Wait for 120 seconds before we try to set weights again.
                     if set_weights_success:
                         logging.info("Successfully set weights.")
                     else:
-                        time.sleep(60)
+                        time.sleep(120)
             except Exception as e:
                 logging.error(f"Error in set weights: {e}")
 


### PR DESCRIPTION
1) Adjust set weight retry from 1 to 2 minutes.
2) Wait 3 minutes on websocket.exceptions.InvalidStatus during the update loop to handle 429 or other errors.