### PR TITLE
Adapting to slower SN1 - SYNTHETIC_MMLU generation

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -103,7 +103,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         kwargs={
             "torch_dtype": torch.bfloat16,
         },
-        eval_block_delay=1600,  # ~5 hours.
+        eval_block_delay=1,  # Irrelevant when using entire dataset.
         norm_validation_constraints=NormValidationConstraints(
             norm_eps_soft=200,
             norm_eps_soft_percent_threshold=0.15,

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -136,7 +136,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
             norm_eps_soft_percent_threshold=0.15,
             norm_eps_hard=1000,
         ),
-        epsilon_func=LinearDecay(0.05, 0.01, 7200 * 5),  # Decay over ~5 days.
+        epsilon_func=LinearDecay(0.05, 0.01, 7200 * 1),  # Decay over ~1 days.
         max_bytes=20 * (1024**3),
     ),
 }

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -73,6 +73,7 @@ PROMPTING_SUBNET_UID = 1
 # The Prompting validator WANDB project and filters
 PROMPTING_WANDB_PROJECT = "macrocosmos/prompting-validators"
 PROMPTING_MAX_AGE = dt.timedelta(hours=4)
+NUM_CONFIGS_TO_SAMPLE = 10
 # Minimum number of samples allowed to consider MMLU as an eval task.
 MIN_ALLOWED_SAMPLES = 50
 # Minimum stake to consider a validator when checking for miners with weights.
@@ -103,7 +104,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         kwargs={
             "torch_dtype": torch.bfloat16,
         },
-        eval_block_delay=1,  # Irrelevant when using entire dataset.
+        eval_block_delay=SYNC_BLOCK_CADENCE + 100,
         norm_validation_constraints=NormValidationConstraints(
             norm_eps_soft=200,
             norm_eps_soft_percent_threshold=0.15,

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -239,7 +239,7 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                         method_id=EvalMethodId.MULTIPLE_CHOICE,
                         dataset_id=DatasetId.SYNTHETIC_MMLU,
                         normalization_id=NormalizationId.NONE,
-                        weight=0.65,
+                        weight=0.30,
                     ),
                     EvalTask(
                         name="WORD_SORTING",
@@ -255,7 +255,7 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                         dataset_id=DatasetId.FINEWEB,
                         normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
                         normalization_kwargs={"ceiling": 20.0},
-                        weight=0.1,
+                        weight=0.35,
                     ),
                     EvalTask(
                         name="IF_EVAL_V2",
@@ -263,7 +263,7 @@ COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
                         dataset_id=DatasetId.SYNTHETIC_IF_EVAL,
                         normalization_id=NormalizationId.NONE,
                         dataset_kwargs={"if_eval_version": IfEvalVersion.V2},
-                        weight=0.2,
+                        weight=0.30,
                     ),
                 ],
             ),

--- a/finetune/datasets/generated/if_eval_loader.py
+++ b/finetune/datasets/generated/if_eval_loader.py
@@ -33,16 +33,10 @@ class IFEvalLoader(DatasetLoader):
         if random_seed:
             random.seed(random_seed)
 
-        # Provide a conservative estimates of samples / hr that are available
-        expected_samples_per_hour = 100
-        oldest_timestamp = dt.datetime.now() - dt.timedelta(
-            hours=math.ceil((max_samples * 2) / expected_samples_per_hour)
-        )
         questions = list(
             MacrocosmosDatasetLoader(
                 random_seed=random_seed,
                 max_samples=max_samples * 2,
-                oldest_sample_timestamp=oldest_timestamp,
                 validator_hotkeys=validator_hotkeys,
             )
         )

--- a/finetune/datasets/generated/mmlu_parser.py
+++ b/finetune/datasets/generated/mmlu_parser.py
@@ -16,7 +16,7 @@ def extract_q_and_a_text(full_prompt: str, answer_char: str) -> Tuple[str, str] 
     if answer_char not in ("A", "B", "C", "D"):
         return None
 
-    regex = "\[Input Question\]\s+(.*)\s+A\. (.*)\s+B\. (.*)\s+C\. (.*)\s+D\. (.*)"
+    regex = "\s+(.*)\s+A\. (.*)\s+B\. (.*)\s+C\. (.*)\s+D\. (.*)"
     match = re.search(regex, full_prompt)
     if not match:
         return None

--- a/finetune/datasets/hugging_face/macrocosmos_dataset_loader.py
+++ b/finetune/datasets/hugging_face/macrocosmos_dataset_loader.py
@@ -4,11 +4,12 @@ import typing
 
 import taoverse.utilities.logging as logging
 import torch
-from datasets import load_dataset, get_dataset_config_names
+from datasets import get_dataset_config_names, load_dataset
 from pytz import timezone
 from retry import retry
 from transformers import PreTrainedTokenizerBase
 
+from constants import NUM_CONFIGS_TO_SAMPLE
 from finetune.datasets.loader import DatasetLoader
 
 # Multiple choice answers for the prompting subnet.
@@ -20,8 +21,6 @@ class MacrocosmosDatasetLoader(DatasetLoader):
     """Loads MMLU data from Macrocosmos' hugging face dataset, produced by subnet 1."""
 
     DATASET_NAME = "macrocosm-os/macrobench-bittensor-01"
-    # Number of configs to sample
-    NUM_CONFIGS_TO_SAMPLE = 10
 
     @staticmethod
     def _create_row_filter(
@@ -79,24 +78,24 @@ class MacrocosmosDatasetLoader(DatasetLoader):
 
         # Get all available configs from the dataset
         all_configs = self._get_all_configs()
-        
+
         if not all_configs:
             raise ValueError("No configs found in the dataset.")
-            
+
         logging.info(f"Found {len(all_configs)} total configs in the dataset")
-        
+
         # Sample NUM_CONFIGS_TO_SAMPLE configs randomly
         sampled_configs = []
-        if len(all_configs) <= self.NUM_CONFIGS_TO_SAMPLE:
+        if len(all_configs) <= NUM_CONFIGS_TO_SAMPLE:
             sampled_configs = all_configs
         else:
-            sampled_configs = random.sample(all_configs, self.NUM_CONFIGS_TO_SAMPLE)
-            
+            sampled_configs = random.sample(all_configs, NUM_CONFIGS_TO_SAMPLE)
+
         logging.info(f"Sampled {len(sampled_configs)} configs: {sampled_configs}")
-        
+
         all_samples = []
         config_sample_counts = {}
-        
+
         # Load samples from each sampled config
         for config in sampled_configs:
             logging.debug(f"Loading samples from config: {config}")
@@ -107,40 +106,44 @@ class MacrocosmosDatasetLoader(DatasetLoader):
                     split=config,
                     download_mode="force_redownload",
                 )
-                
+
                 config_samples = []
-                
+
                 for row in dataset:
                     challenge = row["challenge"]
                     reference = row["reference"]
                     id = row["id"]
-                    
+
                     # Skip invalid reference answers
                     if reference not in PROMPTING_SUBNET_CHOICES:
-                        logging.warning(f"Found invalid reference answer in dataset: {row}")
+                        logging.warning(
+                            f"Found invalid reference answer in dataset: {row}"
+                        )
                         continue
-                        
+
                     # Skip samples not from validator hotkeys if specified
                     if validator_hotkeys and row["hotkey"] not in validator_hotkeys:
                         continue
-                        
+
                     config_samples.append((id, (challenge, reference)))
-                
+
                 all_samples.extend(config_samples)
                 config_sample_counts[config] = len(config_samples)
-                logging.debug(f"Added {len(config_samples)} samples from config {config}")
-                
+                logging.debug(
+                    f"Added {len(config_samples)} samples from config {config}"
+                )
+
             except Exception as e:
                 logging.error(f"Error loading config {config}: {e}")
                 continue
-                
+
         # Shuffle and select samples
         random.shuffle(all_samples)
-        
+
         # Take up to max_samples
         self.buffer = [c_and_r for _, c_and_r in all_samples[:max_samples]]
         self.selected_samples = {id for id, _ in all_samples[:max_samples]}
-        
+
         # Log summary information
         if len(self.buffer) < max_samples:
             logging.info(
@@ -150,12 +153,12 @@ class MacrocosmosDatasetLoader(DatasetLoader):
             logging.info(
                 f"Collected {max_samples} samples out of {len(all_samples)} total available"
             )
-            
+
         # Log detailed config information
         logging.debug(f"Config statistics summary:")
         for config, count in config_sample_counts.items():
             logging.debug(f"  - {config}: {count} samples")
-            
+
         # Store config information for potential retrieval
         self.config_statistics = config_sample_counts
 
@@ -190,7 +193,7 @@ class MacrocosmosDatasetLoader(DatasetLoader):
                     reference,
                 )
             )
-            
+
         return batches
 
     def get_sample(self) -> typing.Tuple[str, str]:
@@ -199,9 +202,11 @@ class MacrocosmosDatasetLoader(DatasetLoader):
         return random.choice(self.buffer)
 
     def get_selected_sample_ids(self) -> typing.Set[str]:
+        """Returns the set of row ids that data was selected from."""
         return self.selected_samples
 
     def get_config_statistics(self) -> typing.Dict[str, int]:
+        """Returns statistics about the splits used and samples collected from each."""
         return self.config_statistics
 
     def __iter__(self):

--- a/finetune/datasets/hugging_face/macrocosmos_dataset_loader.py
+++ b/finetune/datasets/hugging_face/macrocosmos_dataset_loader.py
@@ -4,7 +4,7 @@ import typing
 
 import taoverse.utilities.logging as logging
 import torch
-from datasets import load_dataset
+from datasets import load_dataset, get_dataset_config_names
 from pytz import timezone
 from retry import retry
 from transformers import PreTrainedTokenizerBase
@@ -20,6 +20,8 @@ class MacrocosmosDatasetLoader(DatasetLoader):
     """Loads MMLU data from Macrocosmos' hugging face dataset, produced by subnet 1."""
 
     DATASET_NAME = "macrocosm-os/macrobench-bittensor-01"
+    # Number of configs to sample
+    NUM_CONFIGS_TO_SAMPLE = 10
 
     @staticmethod
     def _create_row_filter(
@@ -43,6 +45,17 @@ class MacrocosmosDatasetLoader(DatasetLoader):
 
         return _func
 
+    @retry(tries=5, delay=1, backoff=2)
+    def _get_all_configs(self) -> typing.List[str]:
+        """Returns all available configs in the dataset."""
+        try:
+            configs = get_dataset_config_names(MacrocosmosDatasetLoader.DATASET_NAME)
+            logging.debug(f"Found {len(configs)} configs in the dataset")
+            return configs
+        except Exception as e:
+            logging.error(f"Error getting dataset configs: {e}")
+            return []
+
     def __init__(
         self,
         random_seed: typing.Optional[int] = None,
@@ -60,97 +73,75 @@ class MacrocosmosDatasetLoader(DatasetLoader):
             newest_sample_timestamp (typing.Optional[dt.datetime], optional): If set, only considers data that was before this timestamp. Must be in UTC.
             validator_hotkeys (typing.Optional[typing.Set[str]], optional): If provided, only considers data from one of these validators.
         """
-        if oldest_sample_timestamp:
-            oldest_sample_timestamp = oldest_sample_timestamp.astimezone(
-                timezone("US/Pacific")
-            )
-        if newest_sample_timestamp:
-            newest_sample_timestamp = newest_sample_timestamp.astimezone(
-                timezone("US/Pacific")
-            )
-
-        logging.debug(
-            f"Fetching samples after {oldest_sample_timestamp} and before {newest_sample_timestamp}"
-        )
-
-        oldest_date = (
-            oldest_sample_timestamp.date() if oldest_sample_timestamp else dt.date.min
-        )
-        newest_date = (
-            newest_sample_timestamp.date() if newest_sample_timestamp else dt.date.max
-        )
-
-        def _need_split(split_name: str) -> bool:
-            """Returns True if the split falls between the oldest and newest sample timestamps."""
-            try:
-                d = dt.datetime.strptime(split_name, "%Y%m%d").date()
-                is_needed = oldest_date <= d <= newest_date
-                logging.debug(
-                    f"Split {split_name} date {d}: oldest={oldest_date} <= d <= newest={newest_date} = {is_needed}"
-                )
-                return is_needed
-            except ValueError as e:
-                logging.debug(f"Invalid date format for split {split_name}: {e}")
-                return False  # If split name is not a valid date format, ignore it
-
-        # Get splits using the datasets library approach
-        all_splits = self._get_splits()
-        logging.debug(f"Found {len(all_splits)} total available splits in the dataset")
-
-        needed_splits = sorted([s for s in all_splits if _need_split(s)])
-        logging.debug(
-            f"Selected {len(needed_splits)} splits that match the date range: {needed_splits}"
-        )
-
-        if not needed_splits:
-            raise ValueError(
-                f"No splits found for samples between {oldest_sample_timestamp} and {newest_sample_timestamp}."
-            )
-
-        all_samples: typing.Set[str] = set()
-        split_sample_counts = {}
-
-        # Fetch all relevant samples from the needed splits.
-        for split in needed_splits:
-            logging.debug(f"Loading samples from split: {split}")
-            dataset = load_dataset(
-                path=MacrocosmosDatasetLoader.DATASET_NAME,
-                name=split,  # Use the split as the config name
-                split=split,  # And also as the split name
-                download_mode="force_redownload",
-            )
-
-            # Get initial size of all_samples to calculate new samples added from this split
-            initial_size = len(all_samples)
-            split_samples = 0
-
-            for row in dataset:
-                challenge = row["challenge"]
-                reference = row["reference"]
-                id = row["id"]
-                all_samples.add((id, (challenge, reference)))
-                split_samples += 1
-
-            new_samples_added = len(all_samples) - initial_size
-            split_sample_counts[split] = {
-                "total_samples": split_samples,
-                "unique_samples_added": new_samples_added,
-            }
-
-            logging.debug(
-                f"Split {split}: {split_samples} total samples, added {new_samples_added} unique samples to collection"
-            )
-
-        # Shuffle and select samples
+        # Set the random seed if provided
         if random_seed:
             random.seed(random_seed)
-        all_samples = sorted(list(all_samples))
-        random.shuffle(all_samples)
 
+        # Get all available configs from the dataset
+        all_configs = self._get_all_configs()
+        
+        if not all_configs:
+            raise ValueError("No configs found in the dataset.")
+            
+        logging.info(f"Found {len(all_configs)} total configs in the dataset")
+        
+        # Sample NUM_CONFIGS_TO_SAMPLE configs randomly
+        sampled_configs = []
+        if len(all_configs) <= self.NUM_CONFIGS_TO_SAMPLE:
+            sampled_configs = all_configs
+        else:
+            sampled_configs = random.sample(all_configs, self.NUM_CONFIGS_TO_SAMPLE)
+            
+        logging.info(f"Sampled {len(sampled_configs)} configs: {sampled_configs}")
+        
+        all_samples = []
+        config_sample_counts = {}
+        
+        # Load samples from each sampled config
+        for config in sampled_configs:
+            logging.debug(f"Loading samples from config: {config}")
+            try:
+                dataset = load_dataset(
+                    path=MacrocosmosDatasetLoader.DATASET_NAME,
+                    name=config,
+                    split=config,
+                    download_mode="force_redownload",
+                )
+                
+                config_samples = []
+                
+                for row in dataset:
+                    challenge = row["challenge"]
+                    reference = row["reference"]
+                    id = row["id"]
+                    
+                    # Skip invalid reference answers
+                    if reference not in PROMPTING_SUBNET_CHOICES:
+                        logging.warning(f"Found invalid reference answer in dataset: {row}")
+                        continue
+                        
+                    # Skip samples not from validator hotkeys if specified
+                    if validator_hotkeys and row["hotkey"] not in validator_hotkeys:
+                        continue
+                        
+                    config_samples.append((id, (challenge, reference)))
+                
+                all_samples.extend(config_samples)
+                config_sample_counts[config] = len(config_samples)
+                logging.debug(f"Added {len(config_samples)} samples from config {config}")
+                
+            except Exception as e:
+                logging.error(f"Error loading config {config}: {e}")
+                continue
+                
+        # Shuffle and select samples
+        random.shuffle(all_samples)
+        
+        # Take up to max_samples
         self.buffer = [c_and_r for _, c_and_r in all_samples[:max_samples]]
         self.selected_samples = {id for id, _ in all_samples[:max_samples]}
-
-        # Log summary information about samples collected
+        
+        # Log summary information
         if len(self.buffer) < max_samples:
             logging.info(
                 f"Did not collect requested {max_samples} samples, only got {len(self.buffer)}"
@@ -159,68 +150,19 @@ class MacrocosmosDatasetLoader(DatasetLoader):
             logging.info(
                 f"Collected {max_samples} samples out of {len(all_samples)} total available"
             )
-
-        # Log detailed split information
-        logging.debug(f"Split statistics summary:")
-        for split, counts in split_sample_counts.items():
-            logging.debug(
-                f"  - {split}: {counts['total_samples']} total samples, {counts['unique_samples_added']} unique samples"
-            )
-
-        # Store split information for potential retrieval
-        self.split_statistics = split_sample_counts
+            
+        # Log detailed config information
+        logging.debug(f"Config statistics summary:")
+        for config, count in config_sample_counts.items():
+            logging.debug(f"  - {config}: {count} samples")
+            
+        # Store config information for potential retrieval
+        self.config_statistics = config_sample_counts
 
     @retry(tries=5, delay=1, backoff=2)
     def _get_splits(self) -> typing.Set[str]:
         """Returns the splits available in the dataset using datasets library directly."""
-        from datetime import datetime, timedelta
-
-        from datasets import get_dataset_config_names
-
-        try:
-            # Try to directly get config names from the dataset
-            configs = get_dataset_config_names(MacrocosmosDatasetLoader.DATASET_NAME)
-            valid_splits = set(configs)
-            logging.debug(
-                f"Found {len(valid_splits)} valid splits directly from dataset configs"
-            )
-
-            if valid_splits:
-                return valid_splits
-        except Exception as e:
-            logging.debug(f"Error getting dataset config names directly: {e}")
-
-        # Fallback: Generate potential date-based splits for a range of dates
-        # Try from 90 days ago to today
-        splits = set()
-        end_date = datetime.now()
-        start_date = end_date - timedelta(days=90)
-
-        current_date = start_date
-        while current_date <= end_date:
-            date_str = current_date.strftime("%Y%m%d")
-            splits.add(date_str)
-            current_date += timedelta(days=1)
-
-        # Filter to only include splits that actually exist in the dataset
-        valid_splits = set()
-        for split in splits:
-            try:
-                # Try to load the dataset with this config - this will fail if it doesn't exist
-                # We're just checking if it exists, not loading the whole dataset
-                from datasets import load_dataset_builder
-
-                builder = load_dataset_builder(
-                    MacrocosmosDatasetLoader.DATASET_NAME, split
-                )
-                valid_splits.add(split)
-                logging.debug(f"Found valid split: {split}")
-            except Exception as e:
-                logging.debug(f"Split {split} not available: {e}")
-                continue
-
-        logging.debug(f"Found {len(valid_splits)} valid splits using direct approach")
-        return valid_splits
+        return set(self._get_all_configs())
 
     def tokenize(
         self, tokenizer: PreTrainedTokenizerBase, sequence_length: int
@@ -248,131 +190,61 @@ class MacrocosmosDatasetLoader(DatasetLoader):
                     reference,
                 )
             )
+            
         return batches
 
     def get_sample(self) -> typing.Tuple[str, str]:
+        if not self.buffer:
+            raise IndexError("MacrocosmosDatasetLoader is empty.")
         return random.choice(self.buffer)
 
     def get_selected_sample_ids(self) -> typing.Set[str]:
-        """Returns the set of row ids that data was selected from."""
         return self.selected_samples
 
-    def get_split_statistics(self) -> typing.Dict[str, typing.Dict[str, int]]:
-        """Returns statistics about the splits used and samples collected from each."""
-        return self.split_statistics
+    def get_config_statistics(self) -> typing.Dict[str, int]:
+        return self.config_statistics
 
     def __iter__(self):
-        return self.buffer.__iter__()
+        return iter(self.buffer)
 
     def __len__(self):
         return len(self.buffer)
 
 
 def main():
-    """
-    Test function to demonstrate the usage of MacrocosmosDatasetLoader.
-    Run this script directly to execute this test function.
-    """
+    """Allows direct invocation of the dataset loader for testing."""
     import argparse
-    import datetime as dt
 
-    from transformers import AutoTokenizer
-
-    # Parse command-line arguments
-    parser = argparse.ArgumentParser(
-        description="Test MacrocosmosDatasetLoader functionality"
-    )
-    parser.add_argument(
-        "--max_samples", type=int, default=5, help="Number of samples to retrieve"
-    )
-    parser.add_argument(
-        "--days_ago",
-        type=int,
-        default=30,
-        help="How many days back to look for samples",
-    )
-    parser.add_argument(
-        "--tokenize", action="store_true", help="Test tokenization functionality"
-    )
-    parser.add_argument(
-        "--model_name",
-        type=str,
-        default="gpt2",
-        help="Model name for tokenizer (if --tokenize is set)",
-    )
-    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
-    parser.add_argument(
-        "--show_split_stats",
-        default=True,
-        action="store_true",
-        help="Show detailed split statistics",
-    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-samples", type=int, default=100)
+    parser.add_argument("--random-seed", type=int, default=None)
+    parser.add_argument("--show-samples", action="store_true")
+    parser.add_argument("--show-split-stats", action="store_true")
     args = parser.parse_args()
 
-    # Set up logging (without using set_trace which doesn't exist)
-    if args.verbose:
-        logging.info("Verbose logging enabled")
+    # Create the dataset loader with the arguments.
+    loader = MacrocosmosDatasetLoader(
+        random_seed=args.random_seed,
+        max_samples=args.max_samples,
+    )
 
-    # Calculate date range
-    now = dt.datetime.now(timezone("US/Pacific"))
-    oldest_date = now - dt.timedelta(days=args.days_ago)
+    # Print summary information.
+    print(f"Loaded {len(loader)} samples.")
 
-    print(f"Initializing MacrocosmosDatasetLoader with max_samples={args.max_samples}")
-    print(f"Looking for samples from {oldest_date} to {now}")
+    # Print split statistics if requested.
+    if args.show_split_stats:
+        print("\nConfig statistics:")
+        for config, count in loader.get_config_statistics().items():
+            print(f"  - {config}: {count} samples")
 
-    try:
-        # Initialize the dataset loader
-        loader = MacrocosmosDatasetLoader(
-            max_samples=args.max_samples,
-            oldest_sample_timestamp=oldest_date,
-            newest_sample_timestamp=now,
-        )
-
-        print(f"Successfully loaded {len(loader)} samples")
-
-        # Show split statistics if requested
-        if args.show_split_stats:
-            print("\nSplit statistics:")
-            for split, stats in loader.get_split_statistics().items():
-                print(
-                    f"  - {split}: {stats['total_samples']} total samples, {stats['unique_samples_added']} unique"
-                )
-
-        # Print a few samples
+    # Print a few samples
+    if args.show_samples:
         print("\nSample data:")
-        for i, (challenge, reference) in enumerate(loader):
-            if i >= 3:  # Limit to 3 samples for display
-                break
-            print(f"\nSample {i+1}:")
-            print(
-                f"Challenge: {challenge[:200]}..."
-                if len(challenge) > 200
-                else f"Challenge: {challenge}"
-            )
-            print(f"Reference answer: {reference}")
-
-        # Test tokenization if requested
-        if args.tokenize:
-            print("\nTesting tokenization:")
-            tokenizer = AutoTokenizer.from_pretrained(args.model_name)
-            tokenized_samples = loader.tokenize(tokenizer, sequence_length=512)
-            print(f"Tokenized {len(tokenized_samples)} samples")
-
-            # Show info about the first tokenized sample
-            if tokenized_samples:
-                first_sample = tokenized_samples[0]
-                print(f"First tokenized sample:")
-                print(f"  Input shape: {first_sample[0].shape}")
-                print(f"  Choices: {first_sample[1]}")
-                print(f"  Correct answer: {first_sample[2]}")
-
-        print("\nTest completed successfully!")
-
-    except Exception as e:
-        print(f"Error during test: {str(e)}")
-        import traceback
-
-        traceback.print_exc()
+        samples = list(loader)
+        for i, (challenge, reference) in enumerate(samples[:5]):
+            print(f"\nSample {i}:")
+            print(f"Challenge: {challenge}")
+            print(f"Reference: {reference}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Main changes
We now use all samples available from the Macrobench dataset.

This means that:
- We now sample 10 configs from the entire Macrobench dataset to create a subset, and choose `max_samples` out of all the samples available in the subset.
- `eval_block_delay` is now irrelevant, set to 1.
- epsilon now decays over a single day, to accommodate this temporary competition. 
- New task weights are: SYNTHETIC_MMLU: 30%, WORD_SORTING: 5%, FINEWEB: 35%, IF_EVAL_V2: 30%