### PR TITLE
Redoing messed up PR

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -33,7 +33,7 @@ from finetune.eval.method import EvalMethodId
 # Project Constants.
 # ---------------------------------
 
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 version_split = __version__.split(".")
 __spec_version__ = (
@@ -44,7 +44,7 @@ __spec_version__ = (
 
 # The version of the validator state. When incremented, causes validators
 # to start from a fresh state.
-VALIDATOR_STATE_VERSION = 6
+VALIDATOR_STATE_VERSION = 7
 
 # Block the subnet was registered.
 GENESIS_BLOCK = 3138611

--- a/finetune/datasets/generated/mmlu_parser.py
+++ b/finetune/datasets/generated/mmlu_parser.py
@@ -16,7 +16,7 @@ def extract_q_and_a_text(full_prompt: str, answer_char: str) -> Tuple[str, str] 
     if answer_char not in ("A", "B", "C", "D"):
         return None
 
-    regex = "\s+(.*)\s+A\. (.*)\s+B\. (.*)\s+C\. (.*)\s+D\. (.*)"
+    regex = "(.*)\s+A\. (.*)\s+B\. (.*)\s+C\. (.*)\s+D\. (.*)"
     match = re.search(regex, full_prompt)
     if not match:
         return None

--- a/finetune/datasets/generated/word_sorting_loader.py
+++ b/finetune/datasets/generated/word_sorting_loader.py
@@ -13,21 +13,22 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+import logging
 import random
 import typing
 
 import nltk
+import numpy as np
 import torch
 from transformers import PreTrainedTokenizerBase
-import numpy as np
 
 from finetune.datasets.loader import DatasetLoader
 
 try:
     from nltk.corpus import words
 except:
+    logging.debug("NLTK words corpus not found, downloading...")
     nltk.download("words", raise_on_error=True)
-
 WORD_SORTING_CHALLENGE_PROMPT = "Sort the following words alphabetically: "
 
 

--- a/finetune/eval/if_eval/sentence_count.py
+++ b/finetune/eval/if_eval/sentence_count.py
@@ -1,9 +1,13 @@
+import logging
+
 import nltk
+
 from finetune.eval.if_eval.rule import IFEvalRule, RuleId
 
 try:
     from nltk.tokenize.punkt import PunktSentenceTokenizer
 except:
+    logging.debug("NLTK punkt not found, downloading...")
     nltk.download("punkt", raise_on_error=True)
 
 

--- a/finetune/eval/method.py
+++ b/finetune/eval/method.py
@@ -115,7 +115,7 @@ def compute_text_loss(
         token_inputs_2 = torch.tensor(batches[1][:prompt_length]).to(device)
 
         if not check_for_reasonable_output(
-            model, token_inputs_1, token_inputs_2, pad_token_id, device
+            model, token_inputs_1, token_inputs_2, pad_token_id
         ):
             return math.inf
     except Exception as e:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1582,7 +1582,7 @@ if __name__ == "__main__":
     try:
         width = os.get_terminal_size().columns
     except:
-        logging.trace(
+        logging.debug(
             "Could not determine terminal size, defaulting to 0", exc_info=True
         )
         width = 0

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -871,7 +871,7 @@ class Validator:
         # We're now sampling from the entire dataset instead of using timestamp filtering
         # We only need to pass the seed, max_samples, and validator_hotkeys
         logging.debug(f"Creating dataset loader with seed {seed}")
-        
+
         try:
             sample_data = MacrocosmosDatasetLoader(
                 random_seed=seed,
@@ -1383,7 +1383,7 @@ class Validator:
                     str(step_log["uid_data"][str(uid)]["competition_id"]),
                 )
             except:
-                pass
+                logging.trace(f"Failed to add row to table for uid {uid}")
         console = Console()
         console.print(table)
 
@@ -1582,6 +1582,9 @@ if __name__ == "__main__":
     try:
         width = os.get_terminal_size().columns
     except:
+        logging.trace(
+            "Could not determine terminal size, defaulting to 0", exc_info=True
+        )
         width = 0
     os.environ["COLUMNS"] = str(max(200, width))
 


### PR DESCRIPTION
Removed unnecessary arguments from `check_for_reasonable_output()` calls
Avoided silent excepts.