### PR TITLE
Validator hotfix

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -159,7 +159,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         kwargs={
             "torch_dtype": torch.bfloat16,
         },
-        eval_block_delay=1600,  # ~5 hours
+        eval_block_delay= SYNC_BLOCK_CADENCE + 100,
         norm_validation_constraints=NormValidationConstraints(
             norm_eps_soft=200,
             norm_eps_soft_percent_threshold=0.15,
@@ -172,7 +172,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
 
 SUNSET_B7_BLOCK = 4_675_163
 
-SUNSET_INSTRUCT_8B_BLOCK = 5_158_632  # midnight GMT+0 on Wednesday, March 19, 2025
+SUNSET_INSTRUCT_8B_BLOCK = 5_158_632  # 23:59 GMT+0 on Tuesday, March 18, 2025
 # Schedule of competitions by block.
 COMPETITION_SCHEDULE_BY_BLOCK: List[Tuple[int, List[Competition]]] = [
     (

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -33,7 +33,7 @@ from finetune.eval.method import EvalMethodId
 # Project Constants.
 # ---------------------------------
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 version_split = __version__.split(".")
 __spec_version__ = (
@@ -44,7 +44,7 @@ __spec_version__ = (
 
 # The version of the validator state. When incremented, causes validators
 # to start from a fresh state.
-VALIDATOR_STATE_VERSION = 8
+VALIDATOR_STATE_VERSION = 9
 
 # Block the subnet was registered.
 GENESIS_BLOCK = 3138611
@@ -159,7 +159,7 @@ MODEL_CONSTRAINTS_BY_COMPETITION_ID: Dict[CompetitionId, ModelConstraints] = {
         kwargs={
             "torch_dtype": torch.bfloat16,
         },
-        eval_block_delay= SYNC_BLOCK_CADENCE + 100,
+        eval_block_delay=SYNC_BLOCK_CADENCE + 100,
         norm_validation_constraints=NormValidationConstraints(
             norm_eps_soft=200,
             norm_eps_soft_percent_threshold=0.15,


### PR DESCRIPTION
- Decreased `eval_block_delay` 
- Fixed bug that kept evaluating models from inactive competitions.
- Fixed huge rain of useless logs.
- Version and vali state bump.